### PR TITLE
Phase 5-7 backend lenses and regression fixes

### DIFF
--- a/app/api/router.py
+++ b/app/api/router.py
@@ -4,6 +4,7 @@ from app.api.routes.auth import router as auth_router
 from app.api.routes.autocomplete import router as autocomplete_router
 from app.api.routes.health import router as health_router
 from app.api.routes.map import router as map_router
+from app.api.routes.recruiting import router as recruiting_router
 from app.api.routes.runs import router as runs_router
 from app.api.routes.sales import router as sales_router
 
@@ -13,4 +14,5 @@ api_router.include_router(auth_router, prefix="/api")
 api_router.include_router(autocomplete_router, prefix="/api")
 api_router.include_router(runs_router, prefix="/api")
 api_router.include_router(map_router, prefix="/api")
+api_router.include_router(recruiting_router, prefix="/api")
 api_router.include_router(sales_router, prefix="/api")

--- a/app/api/router.py
+++ b/app/api/router.py
@@ -5,6 +5,7 @@ from app.api.routes.autocomplete import router as autocomplete_router
 from app.api.routes.health import router as health_router
 from app.api.routes.map import router as map_router
 from app.api.routes.runs import router as runs_router
+from app.api.routes.sales import router as sales_router
 
 api_router = APIRouter()
 api_router.include_router(health_router)
@@ -12,3 +13,4 @@ api_router.include_router(auth_router, prefix="/api")
 api_router.include_router(autocomplete_router, prefix="/api")
 api_router.include_router(runs_router, prefix="/api")
 api_router.include_router(map_router, prefix="/api")
+api_router.include_router(sales_router, prefix="/api")

--- a/app/api/router.py
+++ b/app/api/router.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter
 from app.api.routes.auth import router as auth_router
 from app.api.routes.autocomplete import router as autocomplete_router
 from app.api.routes.health import router as health_router
+from app.api.routes.investor import router as investor_router
 from app.api.routes.map import router as map_router
 from app.api.routes.recruiting import router as recruiting_router
 from app.api.routes.runs import router as runs_router
@@ -14,5 +15,6 @@ api_router.include_router(auth_router, prefix="/api")
 api_router.include_router(autocomplete_router, prefix="/api")
 api_router.include_router(runs_router, prefix="/api")
 api_router.include_router(map_router, prefix="/api")
+api_router.include_router(investor_router, prefix="/api")
 api_router.include_router(recruiting_router, prefix="/api")
 api_router.include_router(sales_router, prefix="/api")

--- a/app/api/routes/investor.py
+++ b/app/api/routes/investor.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import select
+from sqlalchemy.orm import Session, joinedload
+
+from app.api.deps import get_db_session
+from app.core.auth import UserContext, get_current_user
+from app.core.errors import AppError
+from app.db.models import Person, SearchRunEntity
+from app.lenses.investor import (
+    InvestorCompanySummary,
+    InvestorFounderSummary,
+    InvestorLocationSummary,
+    InvestorRunSummaryResponse,
+    InvestorRunSummaryStats,
+    build_investor_signal_summaries,
+)
+from app.runs.service import get_search_run
+
+router = APIRouter(prefix="/runs", tags=["investor"])
+
+
+@router.get("/{run_id}/investor-summary", response_model=InvestorRunSummaryResponse)
+def get_investor_summary(
+    run_id: str,
+    limit: int = Query(default=25, ge=1, le=100),
+    current_user: UserContext = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
+) -> InvestorRunSummaryResponse:
+    run = get_search_run(session=session, current_user=current_user, run_id=run_id)
+    if run.lens != "investor":
+        raise AppError(
+            code="BAD_INPUT",
+            message="Investor summary is only available for investor runs.",
+            status_code=400,
+        )
+
+    entities = session.scalars(
+        select(SearchRunEntity)
+        .where(
+            SearchRunEntity.run_id == run.id,
+            SearchRunEntity.entity_type == "company",
+        )
+        .options(
+            joinedload(SearchRunEntity.company),
+            joinedload(SearchRunEntity.location),
+        )
+        .order_by(SearchRunEntity.lens_score.desc(), SearchRunEntity.rank.asc().nullslast())
+    ).all()
+
+    founder_ids: set[str] = set()
+    for entity in entities:
+        raw_ids = entity.score_breakdown.get("founder_person_ids", [])
+        if isinstance(raw_ids, list):
+            founder_ids.update(str(raw_id) for raw_id in raw_ids)
+
+    founders_by_id: dict[str, Person] = {}
+    if founder_ids:
+        founders = session.scalars(select(Person).where(Person.id.in_(sorted(founder_ids)))).all()
+        founders_by_id = {founder.id: founder for founder in founders}
+
+    company_items: list[InvestorCompanySummary] = []
+    total_score = sum(entity.lens_score for entity in entities)
+    total_signals = 0
+    mapped_companies = sum(
+        1
+        for entity in entities
+        if entity.location is not None and entity.location.geocode_status == "mapped"
+    )
+
+    for entity in entities[:limit]:
+        if entity.company is None:
+            continue
+
+        raw_ids = entity.score_breakdown.get("founder_person_ids", [])
+        founder_people = [
+            founders_by_id[founder_id]
+            for founder_id in raw_ids
+            if isinstance(founder_id, str) and founder_id in founders_by_id
+        ]
+        signals = build_investor_signal_summaries(entity.company)
+        total_signals += len(signals)
+
+        markets = entity.score_breakdown.get("markets", [])
+        categories = entity.score_breakdown.get("categories", [])
+        company_items.append(
+            InvestorCompanySummary(
+                company_id=entity.company.id,
+                name=entity.company.name,
+                domain=entity.company.primary_domain,
+                website=entity.company.website,
+                industry=entity.company.industry,
+                markets=markets if isinstance(markets, list) else [],
+                categories=categories if isinstance(categories, list) else [],
+                employee_count=entity.company.employee_count,
+                funding_total_usd=entity.company.funding_total_usd,
+                funding_last_round_type=entity.company.funding_last_round_type,
+                funding_last_date=(
+                    entity.company.funding_last_date.isoformat()
+                    if entity.company.funding_last_date is not None
+                    else None
+                ),
+                location=InvestorLocationSummary(
+                    location_id=entity.location_id,
+                    raw_label=entity.location.raw_label if entity.location else None,
+                    latitude=entity.location.latitude if entity.location else None,
+                    longitude=entity.location.longitude if entity.location else None,
+                    status=entity.location.geocode_status if entity.location else "missing",
+                    precision=entity.location.geocode_precision if entity.location else None,
+                ),
+                lens_score=entity.lens_score,
+                founder_count=len(founder_people),
+                founders=[
+                    InvestorFounderSummary(
+                        person_id=founder.id,
+                        name=founder.name,
+                        title=founder.current_title,
+                        headline=founder.headline,
+                        current_company_name=founder.current_company_name,
+                        current_company_domain=founder.current_company_domain,
+                        professional_network_url=founder.professional_network_url,
+                    )
+                    for founder in founder_people
+                ],
+                signals=signals,
+                score_breakdown=entity.score_breakdown,
+            )
+        )
+
+    average_score = 0.0
+    if entities:
+        average_score = round(total_score / len(entities), 2)
+
+    return InvestorRunSummaryResponse(
+        run_id=run.id,
+        title=run.title,
+        summary=InvestorRunSummaryStats(
+            company_count=len(entities),
+            mapped_company_count=mapped_companies,
+            founder_count=int(run.result_counts.get("founders", 0)),
+            signal_count=int(run.result_counts.get("signals", total_signals)),
+            average_company_score=average_score,
+            top_company_score=company_items[0].lens_score if company_items else None,
+        ),
+        companies=company_items,
+    )

--- a/app/api/routes/recruiting.py
+++ b/app/api/routes/recruiting.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import select
+from sqlalchemy.orm import Session, joinedload
+
+from app.api.deps import get_db_session
+from app.core.auth import UserContext, get_current_user
+from app.core.errors import AppError
+from app.db.models import SearchRunEntity
+from app.lenses.recruiting import (
+    RecruitingCandidateSummary,
+    RecruitingLocationAggregate,
+    RecruitingRunSummaryResponse,
+    RecruitingRunSummaryStats,
+)
+from app.runs.service import get_search_run
+
+router = APIRouter(prefix="/runs", tags=["recruiting"])
+
+
+@dataclass
+class _LocationAccumulator:
+    location_id: str | None
+    raw_label: str | None
+    latitude: float | None
+    longitude: float | None
+    status: str
+    precision: str | None
+    people_count: int = 0
+    employers: set[str] = field(default_factory=set)
+
+    def to_model(self) -> RecruitingLocationAggregate:
+        employers = sorted(self.employers)
+        return RecruitingLocationAggregate(
+            location_id=self.location_id,
+            raw_label=self.raw_label,
+            latitude=self.latitude,
+            longitude=self.longitude,
+            status=self.status,
+            precision=self.precision,
+            people_count=self.people_count,
+            employer_count=len(employers),
+            employers=employers[:5],
+        )
+
+
+@router.get("/{run_id}/recruiting-summary", response_model=RecruitingRunSummaryResponse)
+def get_recruiting_summary(
+    run_id: str,
+    limit: int = Query(default=25, ge=1, le=100),
+    current_user: UserContext = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
+) -> RecruitingRunSummaryResponse:
+    run = get_search_run(session=session, current_user=current_user, run_id=run_id)
+    if run.lens != "recruiting":
+        raise AppError(
+            code="BAD_INPUT",
+            message="Recruiting summary is only available for recruiting runs.",
+            status_code=400,
+        )
+
+    entities = session.scalars(
+        select(SearchRunEntity)
+        .where(
+            SearchRunEntity.run_id == run.id,
+            SearchRunEntity.entity_type == "person",
+        )
+        .options(
+            joinedload(SearchRunEntity.person),
+            joinedload(SearchRunEntity.location),
+        )
+        .order_by(SearchRunEntity.lens_score.desc(), SearchRunEntity.rank.asc().nullslast())
+    ).all()
+
+    location_accumulators: dict[str | None, _LocationAccumulator] = {}
+    employer_keys: set[str] = set()
+    for entity in entities:
+        person = entity.person
+        if person is None:
+            continue
+
+        employer_key = person.current_company_domain or person.current_company_name
+        if employer_key:
+            employer_keys.add(employer_key)
+
+        location = entity.location
+        key = entity.location_id
+        accumulator = location_accumulators.setdefault(
+            key,
+            _LocationAccumulator(
+                location_id=entity.location_id,
+                raw_label=location.raw_label if location else None,
+                latitude=location.latitude if location else None,
+                longitude=location.longitude if location else None,
+                status=location.geocode_status if location else "missing",
+                precision=location.geocode_precision if location else None,
+            ),
+        )
+        accumulator.people_count += 1
+        if employer_key:
+            accumulator.employers.add(employer_key)
+
+    candidates: list[RecruitingCandidateSummary] = []
+    for entity in entities[:limit]:
+        if entity.person is None:
+            continue
+        person = entity.person
+        location = entity.location
+        candidates.append(
+            RecruitingCandidateSummary(
+                person_id=person.id,
+                name=person.name,
+                title=person.current_title,
+                seniority=person.seniority_level,
+                function_category=person.function_category,
+                current_company_name=person.current_company_name,
+                current_company_domain=person.current_company_domain,
+                headline=person.headline,
+                has_business_email=person.has_business_email,
+                has_phone_number=person.has_phone_number,
+                lens_score=entity.lens_score,
+                location={
+                    "location_id": entity.location_id,
+                    "raw_label": location.raw_label if location else None,
+                    "latitude": location.latitude if location else None,
+                    "longitude": location.longitude if location else None,
+                    "status": location.geocode_status if location else "missing",
+                    "precision": location.geocode_precision if location else None,
+                },
+                score_breakdown=entity.score_breakdown,
+            )
+        )
+
+    mapped_people = sum(
+        1
+        for entity in entities
+        if entity.location is not None and entity.location.geocode_status == "mapped"
+    )
+    average_score = 0.0
+    if entities:
+        average_score = round(sum(entity.lens_score for entity in entities) / len(entities), 2)
+
+    return RecruitingRunSummaryResponse(
+        run_id=run.id,
+        title=run.title,
+        summary=RecruitingRunSummaryStats(
+            people_count=len(entities),
+            mapped_people_count=mapped_people,
+            employer_count=len(employer_keys),
+            average_candidate_score=average_score,
+            top_candidate_score=candidates[0].lens_score if candidates else None,
+        ),
+        candidates=candidates,
+        locations=sorted(
+            (accumulator.to_model() for accumulator in location_accumulators.values()),
+            key=lambda item: (-item.people_count, item.raw_label or ""),
+        ),
+    )

--- a/app/api/routes/recruiting.py
+++ b/app/api/routes/recruiting.py
@@ -50,7 +50,7 @@ class _LocationAccumulator:
 @router.get("/{run_id}/recruiting-summary", response_model=RecruitingRunSummaryResponse)
 def get_recruiting_summary(
     run_id: str,
-    limit: int = Query(default=25, ge=1, le=100),
+    limit: int | None = Query(default=None, ge=1, le=100),
     current_user: UserContext = Depends(get_current_user),
     session: Session = Depends(get_db_session),
 ) -> RecruitingRunSummaryResponse:
@@ -61,6 +61,17 @@ def get_recruiting_summary(
             message="Recruiting summary is only available for recruiting runs.",
             status_code=400,
         )
+
+    effective_limit = limit
+    if effective_limit is None:
+        raw_input = run.input_payload.get("input", {})
+        if not isinstance(raw_input, dict):
+            raw_input = {}
+        raw_default = raw_input.get("top_candidate_limit")
+        if isinstance(raw_default, int) and raw_default > 0:
+            effective_limit = raw_default
+        else:
+            effective_limit = 25
 
     entities = session.scalars(
         select(SearchRunEntity)
@@ -104,7 +115,7 @@ def get_recruiting_summary(
             accumulator.employers.add(employer_key)
 
     candidates: list[RecruitingCandidateSummary] = []
-    for entity in entities[:limit]:
+    for entity in entities[:effective_limit]:
         if entity.person is None:
             continue
         person = entity.person

--- a/app/api/routes/sales.py
+++ b/app/api/routes/sales.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy import select
+from sqlalchemy.orm import Session, joinedload
+
+from app.api.deps import get_db_session
+from app.core.auth import UserContext, get_current_user
+from app.core.errors import AppError
+from app.db.models import Person, SearchRunEntity
+from app.lenses.sales import (
+    SalesBuyerSummary,
+    SalesCompanySummary,
+    SalesLocationSummary,
+    SalesRunSummaryResponse,
+    SalesRunSummaryStats,
+)
+from app.runs.service import get_search_run
+
+router = APIRouter(prefix="/runs", tags=["sales"])
+
+
+@router.get("/{run_id}/sales-summary", response_model=SalesRunSummaryResponse)
+def get_sales_summary(
+    run_id: str,
+    limit: int = Query(default=25, ge=1, le=100),
+    current_user: UserContext = Depends(get_current_user),
+    session: Session = Depends(get_db_session),
+) -> SalesRunSummaryResponse:
+    run = get_search_run(session=session, current_user=current_user, run_id=run_id)
+    if run.lens != "sales":
+        raise AppError(
+            code="BAD_INPUT",
+            message="Sales summary is only available for sales runs.",
+            status_code=400,
+        )
+
+    entities = session.scalars(
+        select(SearchRunEntity)
+        .where(
+            SearchRunEntity.run_id == run.id,
+            SearchRunEntity.entity_type == "company",
+        )
+        .options(
+            joinedload(SearchRunEntity.company),
+            joinedload(SearchRunEntity.location),
+        )
+        .order_by(SearchRunEntity.lens_score.desc(), SearchRunEntity.rank.asc().nullslast())
+    ).all()
+
+    buyer_ids: set[str] = set()
+    for entity in entities:
+        raw_ids = entity.score_breakdown.get("buyer_person_ids", [])
+        if isinstance(raw_ids, list):
+            buyer_ids.update(str(raw_id) for raw_id in raw_ids)
+
+    buyers_by_id: dict[str, Person] = {}
+    if buyer_ids:
+        buyers = session.scalars(select(Person).where(Person.id.in_(sorted(buyer_ids)))).all()
+        buyers_by_id = {buyer.id: buyer for buyer in buyers}
+
+    company_items: list[SalesCompanySummary] = []
+    total_buyers = int(run.result_counts.get("buyers", 0))
+    mapped_companies = sum(
+        1
+        for entity in entities
+        if entity.location is not None and entity.location.geocode_status == "mapped"
+    )
+    total_score = sum(entity.lens_score for entity in entities)
+
+    for entity in entities[:limit]:
+        if entity.company is None:
+            continue
+
+        raw_ids = entity.score_breakdown.get("buyer_person_ids", [])
+        buyer_people = [
+            buyers_by_id[buyer_id]
+            for buyer_id in raw_ids
+            if isinstance(buyer_id, str) and buyer_id in buyers_by_id
+        ]
+        company_items.append(
+            SalesCompanySummary(
+                company_id=entity.company.id,
+                name=entity.company.name,
+                domain=entity.company.primary_domain,
+                industry=entity.company.industry,
+                employee_count=entity.company.employee_count,
+                funding_total_usd=entity.company.funding_total_usd,
+                funding_last_round_type=entity.company.funding_last_round_type,
+                funding_last_date=(
+                    entity.company.funding_last_date.isoformat()
+                    if entity.company.funding_last_date is not None
+                    else None
+                ),
+                location=SalesLocationSummary(
+                    location_id=entity.location_id,
+                    raw_label=entity.location.raw_label if entity.location else None,
+                    latitude=entity.location.latitude if entity.location else None,
+                    longitude=entity.location.longitude if entity.location else None,
+                    status=entity.location.geocode_status if entity.location else "missing",
+                    precision=entity.location.geocode_precision if entity.location else None,
+                ),
+                lens_score=entity.lens_score,
+                buyer_count=len(buyer_people),
+                buyers=[
+                    SalesBuyerSummary(
+                        person_id=buyer.id,
+                        name=buyer.name,
+                        title=buyer.current_title,
+                        seniority=buyer.seniority_level,
+                        headline=buyer.headline,
+                        has_business_email=buyer.has_business_email,
+                        professional_network_url=buyer.professional_network_url,
+                    )
+                    for buyer in buyer_people
+                ],
+                score_breakdown=entity.score_breakdown,
+            )
+        )
+
+    average_score = 0.0
+    if entities:
+        average_score = round(total_score / len(entities), 2)
+
+    return SalesRunSummaryResponse(
+        run_id=run.id,
+        title=run.title,
+        summary=SalesRunSummaryStats(
+            company_count=len(entities),
+            mapped_company_count=mapped_companies,
+            buyer_count=total_buyers,
+            average_company_score=average_score,
+            top_company_score=company_items[0].lens_score if company_items else None,
+        ),
+        companies=company_items,
+    )

--- a/app/lenses/__init__.py
+++ b/app/lenses/__init__.py
@@ -1,5 +1,14 @@
 """Lens-specific backend logic for Locus."""
 
+from app.lenses.recruiting import (
+    RecruitingCandidateSummary,
+    RecruitingLocationAggregate,
+    RecruitingRunInput,
+    RecruitingRunSummaryResponse,
+    RecruitingRunSummaryStats,
+    build_recruiting_search_request,
+    score_recruiting_person,
+)
 from app.lenses.sales import (
     SalesCompanySummary,
     SalesRunInput,
@@ -10,10 +19,17 @@ from app.lenses.sales import (
 )
 
 __all__ = [
+    "RecruitingCandidateSummary",
+    "RecruitingLocationAggregate",
+    "RecruitingRunInput",
+    "RecruitingRunSummaryResponse",
+    "RecruitingRunSummaryStats",
     "SalesCompanySummary",
     "SalesRunInput",
     "SalesRunSummaryResponse",
     "SalesRunSummaryStats",
+    "build_recruiting_search_request",
     "build_sales_buyer_search_request",
+    "score_recruiting_person",
     "score_sales_company",
 ]

--- a/app/lenses/__init__.py
+++ b/app/lenses/__init__.py
@@ -1,0 +1,19 @@
+"""Lens-specific backend logic for Locus."""
+
+from app.lenses.sales import (
+    SalesCompanySummary,
+    SalesRunInput,
+    SalesRunSummaryResponse,
+    SalesRunSummaryStats,
+    build_sales_buyer_search_request,
+    score_sales_company,
+)
+
+__all__ = [
+    "SalesCompanySummary",
+    "SalesRunInput",
+    "SalesRunSummaryResponse",
+    "SalesRunSummaryStats",
+    "build_sales_buyer_search_request",
+    "score_sales_company",
+]

--- a/app/lenses/__init__.py
+++ b/app/lenses/__init__.py
@@ -1,5 +1,15 @@
 """Lens-specific backend logic for Locus."""
 
+from app.lenses.investor import (
+    InvestorCompanySummary,
+    InvestorRunInput,
+    InvestorRunSummaryResponse,
+    InvestorRunSummaryStats,
+    build_investor_company_search_request,
+    build_investor_founder_search_request,
+    build_investor_signal_summaries,
+    score_investor_company,
+)
 from app.lenses.recruiting import (
     RecruitingCandidateSummary,
     RecruitingLocationAggregate,
@@ -19,6 +29,10 @@ from app.lenses.sales import (
 )
 
 __all__ = [
+    "InvestorCompanySummary",
+    "InvestorRunInput",
+    "InvestorRunSummaryResponse",
+    "InvestorRunSummaryStats",
     "RecruitingCandidateSummary",
     "RecruitingLocationAggregate",
     "RecruitingRunInput",
@@ -28,8 +42,12 @@ __all__ = [
     "SalesRunInput",
     "SalesRunSummaryResponse",
     "SalesRunSummaryStats",
+    "build_investor_company_search_request",
+    "build_investor_founder_search_request",
+    "build_investor_signal_summaries",
     "build_recruiting_search_request",
     "build_sales_buyer_search_request",
+    "score_investor_company",
     "score_recruiting_person",
     "score_sales_company",
 ]

--- a/app/lenses/investor.py
+++ b/app/lenses/investor.py
@@ -1,0 +1,518 @@
+from __future__ import annotations
+
+from datetime import datetime, time, timezone
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from app.core.errors import AppError
+from app.crustdata.fields import INVESTOR_COMPANY_FIELDS, INVESTOR_FOUNDER_FIELDS
+from app.crustdata.filters import FilterCondition, FilterGroup, to_safe_contains_pattern
+from app.crustdata.types import CompanySearchRequest, PersonSearchRequest
+from app.db.models import Company, Location
+from app.lenses.scoring import (
+    buyer_coverage_fit,
+    funding_fit,
+    funding_recency_fit,
+    weighted_average,
+)
+
+DEFAULT_FOUNDER_TITLES = [
+    "Founder",
+    "Co-Founder",
+    "CEO",
+    "Chief Executive Officer",
+    "CTO",
+    "Chief Technology Officer",
+]
+
+DEFAULT_FOUNDER_SENIORITIES = ["cxo", "vp", "director"]
+
+
+class InvestorScoreWeights(BaseModel):
+    funding_fit: float = Field(default=0.16, ge=0)
+    funding_recency: float = Field(default=0.16, ge=0)
+    hiring_growth: float = Field(default=0.18, ge=0)
+    follower_growth: float = Field(default=0.14, ge=0)
+    headcount_momentum: float = Field(default=0.16, ge=0)
+    founder_coverage: float = Field(default=0.12, ge=0)
+    market_fit: float = Field(default=0.08, ge=0)
+
+
+class InvestorRunInput(BaseModel):
+    search: CompanySearchRequest
+    target_markets: list[str] = Field(default_factory=list)
+    target_categories: list[str] = Field(default_factory=list)
+    target_industries: list[str] = Field(default_factory=list)
+    min_headcount: int | None = Field(default=None, ge=1)
+    max_headcount: int | None = Field(default=None, ge=1)
+    min_openings_growth_percent: float | None = None
+    min_follower_growth_percent: float | None = None
+    top_company_limit: int = Field(default=5, ge=1, le=25)
+    founders_per_company: int = Field(default=3, ge=0, le=25)
+    founder_titles: list[str] = Field(default_factory=lambda: list(DEFAULT_FOUNDER_TITLES))
+    founder_seniorities: list[str] = Field(
+        default_factory=lambda: list(DEFAULT_FOUNDER_SENIORITIES)
+    )
+    company_fields: list[str] = Field(
+        default_factory=lambda: list(INVESTOR_COMPANY_FIELDS),
+        min_length=1,
+    )
+    founder_fields: list[str] = Field(
+        default_factory=lambda: list(INVESTOR_FOUNDER_FIELDS),
+        min_length=1,
+    )
+    score_weights: InvestorScoreWeights = Field(default_factory=InvestorScoreWeights)
+
+
+class InvestorFounderSummary(BaseModel):
+    person_id: str
+    name: str
+    title: str | None
+    headline: str | None
+    current_company_name: str | None
+    current_company_domain: str | None
+    professional_network_url: str | None
+
+
+class InvestorSignalSummary(BaseModel):
+    signal_type: str
+    title: str
+    description: str | None
+    confidence: float
+    occurred_at: datetime | None
+
+
+class InvestorLocationSummary(BaseModel):
+    location_id: str | None
+    raw_label: str | None
+    latitude: float | None
+    longitude: float | None
+    status: str
+    precision: str | None
+
+
+class InvestorCompanySummary(BaseModel):
+    company_id: str
+    name: str
+    domain: str | None
+    website: str | None
+    industry: str | None
+    markets: list[str]
+    categories: list[str]
+    employee_count: int | None
+    funding_total_usd: float | None
+    funding_last_round_type: str | None
+    funding_last_date: str | None
+    location: InvestorLocationSummary
+    lens_score: float
+    founder_count: int
+    founders: list[InvestorFounderSummary]
+    signals: list[InvestorSignalSummary]
+    score_breakdown: dict[str, Any]
+
+
+class InvestorRunSummaryStats(BaseModel):
+    company_count: int
+    mapped_company_count: int
+    founder_count: int
+    signal_count: int
+    average_company_score: float
+    top_company_score: float | None
+
+
+class InvestorRunSummaryResponse(BaseModel):
+    run_id: str
+    title: str | None
+    summary: InvestorRunSummaryStats
+    companies: list[InvestorCompanySummary]
+
+
+def _normalize_text(value: str | None) -> str:
+    return (value or "").strip().lower()
+
+
+def _merge_filters(
+    base_filters: FilterCondition | FilterGroup | None,
+    conditions: list[FilterCondition],
+) -> FilterCondition | FilterGroup | None:
+    nodes: list[FilterCondition | FilterGroup] = []
+    if base_filters is not None:
+        nodes.append(base_filters)
+    nodes.extend(conditions)
+
+    if not nodes:
+        return None
+    if len(nodes) == 1:
+        return nodes[0]
+    return FilterGroup(op="and", conditions=nodes)
+
+
+def _raw_dict(value: object) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _raw_list(value: object) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _raw_string_list(value: object) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [item.strip() for item in value if isinstance(item, str) and item.strip()]
+    return []
+
+
+def _first_numeric(*values: object) -> float | None:
+    for value in values:
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, int | float):
+            return float(value)
+        if isinstance(value, str):
+            cleaned = value.strip().replace("%", "").replace(",", "")
+            if not cleaned:
+                continue
+            try:
+                return float(cleaned)
+            except ValueError:
+                continue
+    return None
+
+
+def _growth_fit(value: float | None) -> float:
+    if value is None:
+        return 0.35
+    if value >= 100:
+        return 1.0
+    if value >= 50:
+        return 0.85
+    if value >= 20:
+        return 0.65
+    if value > 0:
+        return 0.45
+    if value >= -10:
+        return 0.3
+    return 0.15
+
+
+def _headcount_momentum(company: Company) -> tuple[float, float | None]:
+    raw = _raw_dict(company.raw)
+    roles = _raw_dict(raw.get("roles"))
+    growth = _first_numeric(roles.get("growth_6m"), roles.get("growth_yoy"))
+    if growth is not None:
+        return _growth_fit(growth), growth
+
+    employee_count = company.employee_count
+    if employee_count is None:
+        return 0.3, None
+    if 10 <= employee_count <= 250:
+        return 0.7, None
+    if 251 <= employee_count <= 1000:
+        return 0.55, None
+    return 0.35, None
+
+
+def _company_taxonomy(company: Company) -> tuple[list[str], list[str]]:
+    raw = _raw_dict(company.raw)
+    basic_info = _raw_dict(raw.get("basic_info"))
+    taxonomy = _raw_dict(raw.get("taxonomy"))
+    return (
+        _raw_string_list(basic_info.get("markets")),
+        _raw_string_list(taxonomy.get("categories")),
+    )
+
+
+def _market_fit(
+    company: Company,
+    investor_input: InvestorRunInput,
+) -> tuple[float, dict[str, list[str]]]:
+    markets, categories = _company_taxonomy(company)
+    industry = _normalize_text(company.industry)
+
+    target_markets = {
+        _normalize_text(value) for value in investor_input.target_markets if value.strip()
+    }
+    target_categories = {
+        _normalize_text(value) for value in investor_input.target_categories if value.strip()
+    }
+    target_industries = {
+        _normalize_text(value) for value in investor_input.target_industries if value.strip()
+    }
+
+    if not target_markets and not target_categories and not target_industries:
+        return 0.55, {"markets": markets, "categories": categories}
+
+    normalized_markets = {_normalize_text(value) for value in markets}
+    normalized_categories = {_normalize_text(value) for value in categories}
+
+    matched = (
+        bool(target_markets & normalized_markets)
+        or bool(target_categories & normalized_categories)
+        or (industry != "" and industry in target_industries)
+    )
+    return (1.0 if matched else 0.2), {"markets": markets, "categories": categories}
+
+
+def build_investor_company_search_request(investor_input: InvestorRunInput) -> CompanySearchRequest:
+    if (
+        investor_input.min_headcount is not None
+        and investor_input.max_headcount is not None
+        and investor_input.min_headcount > investor_input.max_headcount
+    ):
+        raise AppError(
+            code="BAD_INPUT",
+            message="min_headcount cannot be greater than max_headcount.",
+            status_code=400,
+        )
+
+    conditions: list[FilterCondition] = []
+    if investor_input.target_markets:
+        conditions.append(
+            FilterCondition(
+                field="basic_info.markets",
+                type="(.)",
+                value=to_safe_contains_pattern(investor_input.target_markets),
+            )
+        )
+    if investor_input.target_categories:
+        conditions.append(
+            FilterCondition(
+                field="taxonomy.categories",
+                type="(.)",
+                value=to_safe_contains_pattern(investor_input.target_categories),
+            )
+        )
+    if investor_input.target_industries:
+        conditions.append(
+            FilterCondition(
+                field="taxonomy.professional_network_industry",
+                type="(.)",
+                value=to_safe_contains_pattern(investor_input.target_industries),
+            )
+        )
+    if investor_input.min_headcount is not None:
+        conditions.append(
+            FilterCondition(field="headcount.total", type="=>", value=investor_input.min_headcount)
+        )
+    if investor_input.max_headcount is not None:
+        conditions.append(
+            FilterCondition(field="headcount.total", type="=<", value=investor_input.max_headcount)
+        )
+    if investor_input.min_openings_growth_percent is not None:
+        conditions.append(
+            FilterCondition(
+                field="hiring.openings_growth_percent",
+                type="=>",
+                value=investor_input.min_openings_growth_percent,
+            )
+        )
+    if investor_input.min_follower_growth_percent is not None:
+        conditions.append(
+            FilterCondition(
+                field="followers.six_months_growth_percent",
+                type="=>",
+                value=investor_input.min_follower_growth_percent,
+            )
+        )
+
+    search = investor_input.search
+    return CompanySearchRequest(
+        fields=investor_input.company_fields or search.fields,
+        filters=_merge_filters(search.filters, conditions),
+        limit=search.limit,
+        cursor=search.cursor,
+    )
+
+
+def build_investor_founder_search_request(
+    *,
+    company: Company,
+    investor_input: InvestorRunInput,
+) -> PersonSearchRequest | None:
+    if investor_input.founders_per_company <= 0:
+        return None
+
+    company_condition: FilterCondition | None = None
+    if company.primary_domain:
+        company_condition = FilterCondition(
+            field="experience.employment_details.current.company_website_domain",
+            type="=",
+            value=company.primary_domain,
+        )
+    elif company.name:
+        company_condition = FilterCondition(
+            field="experience.employment_details.current.company_name",
+            type="=",
+            value=company.name,
+        )
+
+    if company_condition is None:
+        return None
+
+    conditions: list[FilterCondition] = [company_condition]
+    if investor_input.founder_titles:
+        conditions.append(
+            FilterCondition(
+                field="experience.employment_details.current.title",
+                type="(.)",
+                value=to_safe_contains_pattern(investor_input.founder_titles),
+            )
+        )
+    if investor_input.founder_seniorities:
+        conditions.append(
+            FilterCondition(
+                field="experience.employment_details.current.seniority_level",
+                type="in",
+                value=investor_input.founder_seniorities,
+            )
+        )
+
+    filters = conditions[0]
+    if len(conditions) > 1:
+        filters = FilterGroup(op="and", conditions=conditions)
+
+    return PersonSearchRequest(
+        fields=investor_input.founder_fields,
+        filters=filters,
+        limit=investor_input.founders_per_company,
+    )
+
+
+def score_investor_company(
+    *,
+    company: Company,
+    investor_input: InvestorRunInput,
+    founder_count: int,
+    location: Location | None = None,
+) -> tuple[float, dict[str, Any]]:
+    raw = _raw_dict(company.raw)
+    hiring = _raw_dict(raw.get("hiring"))
+    followers = _raw_dict(raw.get("followers"))
+
+    openings_growth = _first_numeric(hiring.get("openings_growth_percent"))
+    follower_growth = _first_numeric(followers.get("six_months_growth_percent"))
+    headcount_score, headcount_growth = _headcount_momentum(company)
+    market_score, taxonomy = _market_fit(company, investor_input)
+    founder_score = buyer_coverage_fit(founder_count, investor_input.founders_per_company)
+
+    weights = investor_input.score_weights
+    weighted_inputs = {
+        "funding_fit": (
+            funding_fit(company.funding_total_usd, company.funding_last_round_amount_usd),
+            weights.funding_fit,
+        ),
+        "funding_recency": (
+            funding_recency_fit(company.funding_last_date),
+            weights.funding_recency,
+        ),
+        "hiring_growth": (_growth_fit(openings_growth), weights.hiring_growth),
+        "follower_growth": (_growth_fit(follower_growth), weights.follower_growth),
+        "headcount_momentum": (headcount_score, weights.headcount_momentum),
+        "founder_coverage": (
+            founder_score,
+            weights.founder_coverage if investor_input.founders_per_company > 0 else 0.0,
+        ),
+        "market_fit": (market_score, weights.market_fit),
+    }
+    score = round(weighted_average(weighted_inputs) * 100, 2)
+
+    return score, {
+        "funding_fit": round(weighted_inputs["funding_fit"][0], 3),
+        "funding_recency": round(weighted_inputs["funding_recency"][0], 3),
+        "hiring_growth": round(weighted_inputs["hiring_growth"][0], 3),
+        "follower_growth": round(weighted_inputs["follower_growth"][0], 3),
+        "headcount_momentum": round(headcount_score, 3),
+        "founder_coverage": round(founder_score, 3),
+        "market_fit": round(market_score, 3),
+        "openings_growth_percent": openings_growth,
+        "follower_growth_percent": follower_growth,
+        "headcount_growth_percent": headcount_growth,
+        "markets": taxonomy["markets"],
+        "categories": taxonomy["categories"],
+        "founder_target": investor_input.founders_per_company,
+        "company_location_status": location.geocode_status if location else "missing",
+        "company_location_precision": location.geocode_precision if location else None,
+    }
+
+
+def build_investor_signal_summaries(company: Company) -> list[InvestorSignalSummary]:
+    raw = _raw_dict(company.raw)
+    hiring = _raw_dict(raw.get("hiring"))
+    roles = _raw_dict(raw.get("roles"))
+
+    signals: list[InvestorSignalSummary] = []
+    if (
+        company.funding_total_usd is not None
+        or company.funding_last_round_amount_usd is not None
+        or company.funding_last_date is not None
+    ):
+        description_parts: list[str] = []
+        if company.funding_last_round_amount_usd is not None:
+            description_parts.append(
+                f"Last round ${company.funding_last_round_amount_usd:,.0f}"
+            )
+        if company.funding_total_usd is not None:
+            description_parts.append(f"Total funding ${company.funding_total_usd:,.0f}")
+        occurred_at = None
+        if company.funding_last_date is not None:
+            occurred_at = datetime.combine(
+                company.funding_last_date,
+                time.min,
+                tzinfo=timezone.utc,
+            )
+            description_parts.append(f"Last raised on {company.funding_last_date.isoformat()}")
+        signals.append(
+            InvestorSignalSummary(
+                signal_type="funding",
+                title=(
+                    f"{company.funding_last_round_type.title()} funding"
+                    if company.funding_last_round_type
+                    else "Funding activity"
+                ),
+                description=" | ".join(description_parts) if description_parts else None,
+                confidence=0.9 if occurred_at is not None else 0.75,
+                occurred_at=occurred_at,
+            )
+        )
+
+    openings_count = _first_numeric(hiring.get("openings_count"))
+    openings_growth = _first_numeric(hiring.get("openings_growth_percent"))
+    if openings_count is not None or openings_growth is not None:
+        description_parts = []
+        if openings_count is not None:
+            description_parts.append(f"{int(openings_count)} open roles")
+        if openings_growth is not None:
+            description_parts.append(f"{openings_growth:.1f}% openings growth")
+        signals.append(
+            InvestorSignalSummary(
+                signal_type="hiring",
+                title="Hiring momentum",
+                description=" | ".join(description_parts) if description_parts else None,
+                confidence=0.85 if openings_growth is not None and openings_growth > 0 else 0.65,
+                occurred_at=None,
+            )
+        )
+
+    growth_6m = _first_numeric(roles.get("growth_6m"))
+    growth_yoy = _first_numeric(roles.get("growth_yoy"))
+    if company.employee_count is not None or growth_6m is not None or growth_yoy is not None:
+        description_parts = []
+        if company.employee_count is not None:
+            description_parts.append(f"{company.employee_count} employees")
+        if growth_6m is not None:
+            description_parts.append(f"{growth_6m:.1f}% headcount growth in 6m")
+        if growth_yoy is not None:
+            description_parts.append(f"{growth_yoy:.1f}% headcount growth YoY")
+        signals.append(
+            InvestorSignalSummary(
+                signal_type="headcount",
+                title="Headcount signal",
+                description=" | ".join(description_parts) if description_parts else None,
+                confidence=0.8 if growth_6m is not None or growth_yoy is not None else 0.6,
+                occurred_at=None,
+            )
+        )
+
+    return signals

--- a/app/lenses/recruiting.py
+++ b/app/lenses/recruiting.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from app.crustdata.filters import FilterCondition, FilterGroup, to_safe_contains_pattern
+from app.crustdata.types import PersonSearchRequest
+from app.db.models import Location, Person
+from app.lenses.scoring import weighted_average
+
+DEFAULT_CANDIDATE_FIELDS = [
+    "basic_profile.name",
+    "basic_profile.headline",
+    "basic_profile.location",
+    "experience.employment_details.current.title",
+    "experience.employment_details.current.company_name",
+    "experience.employment_details.current.company_website_domain",
+    "experience.employment_details.current.seniority_level",
+    "experience.employment_details.current.function_category",
+    "contact.has_business_email",
+    "contact.has_personal_email",
+    "contact.has_phone_number",
+    "social_handles.professional_network_identifier.profile_url",
+]
+
+
+class RadiusFilter(BaseModel):
+    field: str = "basic_profile.location"
+    latitude: float
+    longitude: float
+    radius_km: float = Field(ge=1, le=1000)
+
+
+class RecruitingScoreWeights(BaseModel):
+    title_fit: float = Field(default=0.24, ge=0)
+    seniority_fit: float = Field(default=0.18, ge=0)
+    function_fit: float = Field(default=0.14, ge=0)
+    skill_fit: float = Field(default=0.18, ge=0)
+    contact_fit: float = Field(default=0.14, ge=0)
+    employer_signal: float = Field(default=0.12, ge=0)
+
+
+class RecruitingRunInput(BaseModel):
+    search: PersonSearchRequest
+    target_titles: list[str] = Field(default_factory=list)
+    target_seniorities: list[str] = Field(default_factory=list)
+    target_functions: list[str] = Field(default_factory=list)
+    target_skills: list[str] = Field(default_factory=list)
+    radius: RadiusFilter | None = None
+    candidate_fields: list[str] = Field(default_factory=lambda: list(DEFAULT_CANDIDATE_FIELDS))
+    top_candidate_limit: int = Field(default=25, ge=1, le=100)
+    score_weights: RecruitingScoreWeights = Field(default_factory=RecruitingScoreWeights)
+
+
+class RecruitingCandidateSummary(BaseModel):
+    person_id: str
+    name: str
+    title: str | None
+    seniority: str | None
+    function_category: str | None
+    current_company_name: str | None
+    current_company_domain: str | None
+    headline: str | None
+    has_business_email: bool | None
+    has_phone_number: bool | None
+    lens_score: float
+    location: dict[str, Any]
+    score_breakdown: dict[str, Any]
+
+
+class RecruitingLocationAggregate(BaseModel):
+    location_id: str | None
+    raw_label: str | None
+    latitude: float | None
+    longitude: float | None
+    status: str
+    precision: str | None
+    people_count: int
+    employer_count: int
+    employers: list[str]
+
+
+class RecruitingRunSummaryStats(BaseModel):
+    people_count: int
+    mapped_people_count: int
+    employer_count: int
+    average_candidate_score: float
+    top_candidate_score: float | None
+
+
+class RecruitingRunSummaryResponse(BaseModel):
+    run_id: str
+    title: str | None
+    summary: RecruitingRunSummaryStats
+    candidates: list[RecruitingCandidateSummary]
+    locations: list[RecruitingLocationAggregate]
+
+
+def _normalize_text(value: str | None) -> str:
+    return (value or "").strip().lower()
+
+
+def _contains_any(value: str | None, targets: list[str]) -> bool:
+    haystack = _normalize_text(value)
+    normalized_targets = [_normalize_text(target) for target in targets if _normalize_text(target)]
+    if not normalized_targets:
+        return False
+    return any(target in haystack for target in normalized_targets)
+
+
+def _exact_match(value: str | None, targets: list[str]) -> bool:
+    normalized_value = _normalize_text(value)
+    normalized_targets = {_normalize_text(target) for target in targets if _normalize_text(target)}
+    if not normalized_targets:
+        return False
+    return normalized_value in normalized_targets
+
+
+def _merge_filters(
+    base_filters: FilterCondition | FilterGroup | None,
+    conditions: list[FilterCondition],
+) -> FilterCondition | FilterGroup | None:
+    nodes: list[FilterCondition | FilterGroup] = []
+    if base_filters is not None:
+        nodes.append(base_filters)
+    nodes.extend(conditions)
+
+    if not nodes:
+        return None
+    if len(nodes) == 1:
+        return nodes[0]
+    return FilterGroup(op="and", conditions=nodes)
+
+
+def build_recruiting_search_request(recruiting_input: RecruitingRunInput) -> PersonSearchRequest:
+    conditions: list[FilterCondition] = []
+    if recruiting_input.target_titles:
+        conditions.append(
+            FilterCondition(
+                field="experience.employment_details.current.title",
+                type="(.)",
+                value=to_safe_contains_pattern(recruiting_input.target_titles),
+            )
+        )
+    if recruiting_input.target_seniorities:
+        conditions.append(
+            FilterCondition(
+                field="experience.employment_details.current.seniority_level",
+                type="in",
+                value=recruiting_input.target_seniorities,
+            )
+        )
+    if recruiting_input.target_functions:
+        conditions.append(
+            FilterCondition(
+                field="experience.employment_details.current.function_category",
+                type="in",
+                value=recruiting_input.target_functions,
+            )
+        )
+    if recruiting_input.target_skills:
+        conditions.append(
+            FilterCondition(
+                field="basic_profile.headline",
+                type="(.)",
+                value=to_safe_contains_pattern(recruiting_input.target_skills),
+            )
+        )
+    if recruiting_input.radius is not None:
+        conditions.append(
+            FilterCondition(
+                field=recruiting_input.radius.field,
+                type="geo_distance",
+                value={
+                    "latitude": recruiting_input.radius.latitude,
+                    "longitude": recruiting_input.radius.longitude,
+                    "radius_km": recruiting_input.radius.radius_km,
+                },
+            )
+        )
+
+    search = recruiting_input.search
+    return PersonSearchRequest(
+        fields=recruiting_input.candidate_fields or search.fields,
+        filters=_merge_filters(search.filters, conditions),
+        limit=search.limit,
+        cursor=search.cursor,
+    )
+
+
+def score_recruiting_person(
+    *,
+    person: Person,
+    recruiting_input: RecruitingRunInput,
+    location: Location | None = None,
+) -> tuple[float, dict[str, Any]]:
+    title_score = 0.6
+    if recruiting_input.target_titles:
+        title_score = (
+            1.0
+            if _contains_any(person.current_title, recruiting_input.target_titles)
+            else 0.1
+        )
+
+    seniority_score = 0.6
+    if recruiting_input.target_seniorities:
+        seniority_score = (
+            1.0
+            if _exact_match(person.seniority_level, recruiting_input.target_seniorities)
+            else 0.1
+        )
+
+    function_score = 0.6
+    if recruiting_input.target_functions:
+        function_score = (
+            1.0
+            if _exact_match(person.function_category, recruiting_input.target_functions)
+            else 0.1
+        )
+
+    skill_score = 0.6
+    if recruiting_input.target_skills:
+        headline = " ".join(part for part in [person.headline, person.current_title] if part)
+        skill_score = 1.0 if _contains_any(headline, recruiting_input.target_skills) else 0.1
+
+    contact_score = 0.2
+    if person.has_business_email or person.has_phone_number:
+        contact_score = 1.0
+    elif person.has_personal_email:
+        contact_score = 0.65
+
+    employer_signal = 0.25
+    if person.current_company_name and person.current_company_domain:
+        employer_signal = 1.0
+    elif person.current_company_name or person.current_company_domain:
+        employer_signal = 0.65
+
+    weights = recruiting_input.score_weights
+    weighted_inputs = {
+        "title_fit": (title_score, weights.title_fit),
+        "seniority_fit": (seniority_score, weights.seniority_fit),
+        "function_fit": (function_score, weights.function_fit),
+        "skill_fit": (skill_score, weights.skill_fit),
+        "contact_fit": (contact_score, weights.contact_fit),
+        "employer_signal": (employer_signal, weights.employer_signal),
+    }
+    score = round(weighted_average(weighted_inputs) * 100, 2)
+
+    return score, {
+        "title_fit": round(title_score, 3),
+        "seniority_fit": round(seniority_score, 3),
+        "function_fit": round(function_score, 3),
+        "skill_fit": round(skill_score, 3),
+        "contact_fit": round(contact_score, 3),
+        "employer_signal": round(employer_signal, 3),
+        "target_titles": recruiting_input.target_titles,
+        "target_seniorities": recruiting_input.target_seniorities,
+        "target_functions": recruiting_input.target_functions,
+        "target_skills": recruiting_input.target_skills,
+        "radius_km": recruiting_input.radius.radius_km if recruiting_input.radius else None,
+        "location_status": location.geocode_status if location else "missing",
+        "location_precision": location.geocode_precision if location else None,
+    }

--- a/app/lenses/sales.py
+++ b/app/lenses/sales.py
@@ -54,7 +54,10 @@ class SalesRunInput(BaseModel):
     buyers_per_company: int = Field(default=3, ge=0, le=25)
     buyer_titles: list[str] = Field(default_factory=lambda: list(DEFAULT_BUYER_TITLES))
     buyer_seniorities: list[str] = Field(default_factory=lambda: list(DEFAULT_BUYER_SENIORITIES))
-    buyer_fields: list[str] = Field(default_factory=lambda: list(DEFAULT_BUYER_FIELDS))
+    buyer_fields: list[str] = Field(
+        default_factory=lambda: list(DEFAULT_BUYER_FIELDS),
+        min_length=1,
+    )
     preferred_industries: list[str] = Field(default_factory=list)
     score_weights: SalesScoreWeights = Field(default_factory=SalesScoreWeights)
 

--- a/app/lenses/sales.py
+++ b/app/lenses/sales.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from app.crustdata.filters import FilterCondition, FilterGroup, to_safe_contains_pattern
+from app.crustdata.types import CompanySearchRequest, PersonSearchRequest
+from app.db.models import Company, Location
+from app.lenses.scoring import (
+    buyer_coverage_fit,
+    employee_fit,
+    funding_fit,
+    funding_recency_fit,
+    weighted_average,
+)
+
+DEFAULT_BUYER_FIELDS = [
+    "basic_profile.name",
+    "basic_profile.headline",
+    "basic_profile.location",
+    "experience.employment_details.current.title",
+    "experience.employment_details.current.company_name",
+    "experience.employment_details.current.company_website_domain",
+    "experience.employment_details.current.seniority_level",
+    "contact.has_business_email",
+    "social_handles.professional_network_identifier.profile_url",
+]
+
+DEFAULT_BUYER_TITLES = [
+    "CEO",
+    "Founder",
+    "Co-Founder",
+    "VP Sales",
+    "Head of Sales",
+    "Revenue",
+]
+
+DEFAULT_BUYER_SENIORITIES = ["cxo", "vp", "director"]
+
+
+class SalesScoreWeights(BaseModel):
+    employee_fit: float = Field(default=0.28, ge=0)
+    funding_fit: float = Field(default=0.18, ge=0)
+    funding_recency: float = Field(default=0.16, ge=0)
+    industry_fit: float = Field(default=0.12, ge=0)
+    hq_signal: float = Field(default=0.08, ge=0)
+    buyer_coverage: float = Field(default=0.18, ge=0)
+
+
+class SalesRunInput(BaseModel):
+    search: CompanySearchRequest
+    top_company_limit: int = Field(default=5, ge=1, le=25)
+    buyers_per_company: int = Field(default=3, ge=0, le=25)
+    buyer_titles: list[str] = Field(default_factory=lambda: list(DEFAULT_BUYER_TITLES))
+    buyer_seniorities: list[str] = Field(default_factory=lambda: list(DEFAULT_BUYER_SENIORITIES))
+    buyer_fields: list[str] = Field(default_factory=lambda: list(DEFAULT_BUYER_FIELDS))
+    preferred_industries: list[str] = Field(default_factory=list)
+    score_weights: SalesScoreWeights = Field(default_factory=SalesScoreWeights)
+
+
+class SalesBuyerSummary(BaseModel):
+    person_id: str
+    name: str
+    title: str | None
+    seniority: str | None
+    headline: str | None
+    has_business_email: bool | None
+    professional_network_url: str | None
+
+
+class SalesLocationSummary(BaseModel):
+    location_id: str | None
+    raw_label: str | None
+    latitude: float | None
+    longitude: float | None
+    status: str
+    precision: str | None
+
+
+class SalesCompanySummary(BaseModel):
+    company_id: str
+    name: str
+    domain: str | None
+    industry: str | None
+    employee_count: int | None
+    funding_total_usd: float | None
+    funding_last_round_type: str | None
+    funding_last_date: str | None
+    location: SalesLocationSummary
+    lens_score: float
+    buyer_count: int
+    buyers: list[SalesBuyerSummary]
+    score_breakdown: dict[str, Any]
+
+
+class SalesRunSummaryStats(BaseModel):
+    company_count: int
+    mapped_company_count: int
+    buyer_count: int
+    average_company_score: float
+    top_company_score: float | None
+
+
+class SalesRunSummaryResponse(BaseModel):
+    run_id: str
+    title: str | None
+    summary: SalesRunSummaryStats
+    companies: list[SalesCompanySummary]
+
+
+def build_sales_buyer_search_request(
+    *,
+    company: Company,
+    sales_input: SalesRunInput,
+) -> PersonSearchRequest | None:
+    if sales_input.buyers_per_company <= 0:
+        return None
+
+    company_condition: FilterCondition | None = None
+    if company.primary_domain:
+        company_condition = FilterCondition(
+            field="experience.employment_details.current.company_website_domain",
+            type="=",
+            value=company.primary_domain,
+        )
+    elif company.name:
+        company_condition = FilterCondition(
+            field="experience.employment_details.current.company_name",
+            type="=",
+            value=company.name,
+        )
+
+    if company_condition is None:
+        return None
+
+    conditions: list[FilterCondition] = [company_condition]
+    if sales_input.buyer_titles:
+        conditions.append(
+            FilterCondition(
+                field="experience.employment_details.current.title",
+                type="(.)",
+                value=to_safe_contains_pattern(sales_input.buyer_titles),
+            )
+        )
+    if sales_input.buyer_seniorities:
+        conditions.append(
+            FilterCondition(
+                field="experience.employment_details.current.seniority_level",
+                type="in",
+                value=sales_input.buyer_seniorities,
+            )
+        )
+
+    filters = conditions[0]
+    if len(conditions) > 1:
+        filters = FilterGroup(op="and", conditions=conditions)
+
+    return PersonSearchRequest(
+        fields=sales_input.buyer_fields,
+        filters=filters,
+        limit=sales_input.buyers_per_company,
+    )
+
+
+def score_sales_company(
+    *,
+    company: Company,
+    sales_input: SalesRunInput,
+    buyer_count: int,
+    location: Location | None = None,
+) -> tuple[float, dict[str, Any]]:
+    preferred_industries = {
+        industry.strip().lower()
+        for industry in sales_input.preferred_industries
+        if industry.strip()
+    }
+    company_industry = (company.industry or "").strip().lower()
+
+    employee_score = employee_fit(company.employee_count)
+    funding_score = funding_fit(company.funding_total_usd, company.funding_last_round_amount_usd)
+    recency_score = funding_recency_fit(company.funding_last_date)
+    industry_score = 0.6
+    if preferred_industries:
+        industry_score = 1.0 if company_industry in preferred_industries else 0.2
+    hq_score = 1.0 if company.hq_location_id else 0.3
+    buyer_score = buyer_coverage_fit(buyer_count, sales_input.buyers_per_company)
+
+    weights = sales_input.score_weights
+    weighted_inputs = {
+        "employee_fit": (employee_score, weights.employee_fit),
+        "funding_fit": (funding_score, weights.funding_fit),
+        "funding_recency": (recency_score, weights.funding_recency),
+        "industry_fit": (industry_score, weights.industry_fit),
+        "hq_signal": (hq_score, weights.hq_signal),
+        "buyer_coverage": (
+            buyer_score,
+            weights.buyer_coverage if sales_input.buyers_per_company > 0 else 0.0,
+        ),
+    }
+    score = round(weighted_average(weighted_inputs) * 100, 2)
+
+    return score, {
+        "employee_fit": round(employee_score, 3),
+        "funding_fit": round(funding_score, 3),
+        "funding_recency": round(recency_score, 3),
+        "industry_fit": round(industry_score, 3),
+        "hq_signal": round(hq_score, 3),
+        "buyer_coverage": round(buyer_score, 3),
+        "preferred_industries": sorted(preferred_industries),
+        "buyer_target": sales_input.buyers_per_company,
+        "company_location_status": location.geocode_status if location else "missing",
+        "company_location_precision": location.geocode_precision if location else None,
+    }

--- a/app/lenses/scoring.py
+++ b/app/lenses/scoring.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from datetime import date
+
+
+def clamp(value: float, *, minimum: float = 0.0, maximum: float = 1.0) -> float:
+    return max(minimum, min(maximum, value))
+
+
+def weighted_average(scores: dict[str, tuple[float, float]]) -> float:
+    total_weight = sum(weight for _value, weight in scores.values() if weight > 0)
+    if total_weight <= 0:
+        return 0.0
+
+    weighted_sum = sum(value * weight for value, weight in scores.values() if weight > 0)
+    return weighted_sum / total_weight
+
+
+def employee_fit(employee_count: int | None) -> float:
+    if employee_count is None:
+        return 0.35
+    if 50 <= employee_count <= 500:
+        return 1.0
+    if 20 <= employee_count <= 1500:
+        return 0.8
+    if 10 <= employee_count <= 5000:
+        return 0.55
+    return 0.2
+
+
+def funding_fit(total_funding_usd: float | None, last_round_amount_usd: float | None) -> float:
+    funding_signal = max(total_funding_usd or 0.0, last_round_amount_usd or 0.0)
+    if funding_signal >= 50_000_000:
+        return 1.0
+    if funding_signal >= 10_000_000:
+        return 0.85
+    if funding_signal >= 1_000_000:
+        return 0.65
+    if funding_signal > 0:
+        return 0.45
+    return 0.2
+
+
+def funding_recency_fit(last_funding_date: date | None, *, today: date | None = None) -> float:
+    if last_funding_date is None:
+        return 0.35
+
+    reference = today or date.today()
+    age_days = (reference - last_funding_date).days
+    if age_days <= 365:
+        return 1.0
+    if age_days <= 730:
+        return 0.8
+    if age_days <= 1460:
+        return 0.55
+    return 0.25
+
+
+def buyer_coverage_fit(buyer_count: int, target_buyers: int) -> float:
+    if target_buyers <= 0:
+        return 0.0
+    return clamp(buyer_count / target_buyers)

--- a/app/runs/schemas.py
+++ b/app/runs/schemas.py
@@ -3,14 +3,11 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 from app.crustdata.types import CompanySearchRequest, PersonSearchRequest
 from app.db.models import SearchRun
-
-
-class SalesRunInput(BaseModel):
-    search: CompanySearchRequest
+from app.lenses.sales import SalesRunInput
 
 
 class RecruitingRunInput(BaseModel):
@@ -25,6 +22,30 @@ class CreateRunRequest(BaseModel):
     lens: Literal["sales", "recruiting", "investor"]
     title: str | None = None
     input: SalesRunInput | RecruitingRunInput | InvestorRunInput
+
+    @model_validator(mode="before")
+    @classmethod
+    def coerce_input_for_lens(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+
+        lens = data.get("lens")
+        raw_input = data.get("input")
+        if lens is None or raw_input is None:
+            return data
+
+        input_models = {
+            "sales": SalesRunInput,
+            "recruiting": RecruitingRunInput,
+            "investor": InvestorRunInput,
+        }
+        model = input_models.get(lens)
+        if model is None:
+            return data
+
+        coerced = dict(data)
+        coerced["input"] = model.model_validate(raw_input)
+        return coerced
 
 
 class CreateRunResponse(BaseModel):

--- a/app/runs/schemas.py
+++ b/app/runs/schemas.py
@@ -5,14 +5,10 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, model_validator
 
-from app.crustdata.types import CompanySearchRequest
 from app.db.models import SearchRun
+from app.lenses.investor import InvestorRunInput
 from app.lenses.recruiting import RecruitingRunInput
 from app.lenses.sales import SalesRunInput
-
-
-class InvestorRunInput(BaseModel):
-    search: CompanySearchRequest
 
 
 class CreateRunRequest(BaseModel):

--- a/app/runs/schemas.py
+++ b/app/runs/schemas.py
@@ -5,13 +5,10 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, model_validator
 
-from app.crustdata.types import CompanySearchRequest, PersonSearchRequest
+from app.crustdata.types import CompanySearchRequest
 from app.db.models import SearchRun
+from app.lenses.recruiting import RecruitingRunInput
 from app.lenses.sales import SalesRunInput
-
-
-class RecruitingRunInput(BaseModel):
-    search: PersonSearchRequest
 
 
 class InvestorRunInput(BaseModel):

--- a/app/runs/service.py
+++ b/app/runs/service.py
@@ -11,7 +11,14 @@ from app.core.errors import AppError
 from app.crustdata.client import CrustdataClient
 from app.crustdata.company import company_search
 from app.crustdata.person import person_search
-from app.db.models import Company, Location, Person, SearchRun, SearchRunEntity, User
+from app.db.models import Company, Location, Person, SearchRun, SearchRunEntity, Signal, User
+from app.lenses.investor import (
+    InvestorRunInput,
+    build_investor_company_search_request,
+    build_investor_founder_search_request,
+    build_investor_signal_summaries,
+    score_investor_company,
+)
 from app.lenses.recruiting import (
     RecruitingRunInput,
     build_recruiting_search_request,
@@ -263,6 +270,46 @@ def _build_person_entities(
     return entities
 
 
+def _upsert_company_signal(
+    *,
+    session: Session,
+    company: Company,
+    location: Location | None,
+    signal_type: str,
+    title: str,
+    description: str | None,
+    confidence: float,
+    occurred_at: datetime | None,
+    raw: dict,
+) -> Signal:
+    signal = session.scalar(
+        select(Signal).where(
+            Signal.company_id == company.id,
+            Signal.signal_type == signal_type,
+            Signal.source == "crustdata",
+            Signal.title == title,
+        )
+    )
+    if signal is None:
+        signal = Signal(
+            entity_type="company",
+            company_id=company.id,
+            location_id=location.id if location is not None else None,
+            signal_type=signal_type,
+            source="crustdata",
+            title=title,
+        )
+        session.add(signal)
+
+    signal.location_id = location.id if location is not None else None
+    signal.description = description
+    signal.confidence = confidence
+    signal.occurred_at = occurred_at
+    signal.raw = raw
+    session.flush()
+    return signal
+
+
 def _run_company_search(
     *,
     session: Session,
@@ -329,6 +376,119 @@ def _run_recruiting_search(
     counts = _calculate_result_counts(entity_type="person", entities=entity_models)
     counts["employers"] = len(employers)
     return entity_models, counts, {"company_search_requests": 0, "person_search_requests": 1}
+
+
+def _run_investor_search(
+    *,
+    session: Session,
+    run: SearchRun,
+    client: CrustdataClient,
+    request: CreateRunRequest,
+) -> tuple[list[SearchRunEntity], dict[str, int | str], dict[str, int]]:
+    if not isinstance(request.input, InvestorRunInput):
+        raise AppError(
+            code="BAD_INPUT",
+            message="Investor runs require investor-specific input.",
+            status_code=400,
+        )
+
+    search_request = build_investor_company_search_request(request.input)
+    payload = company_search(client, search_request)
+    company_entities = _build_company_entities(session=session, run=run, payload=payload)
+
+    founder_ids_by_company: dict[str | None, list[str]] = {}
+    person_search_requests = 0
+    unique_founder_ids: set[str] = set()
+    signal_count = 0
+
+    base_scores: list[tuple[SearchRunEntity, Company, float, dict]] = []
+    for entity, company in company_entities:
+        score, breakdown = score_investor_company(
+            company=company,
+            investor_input=request.input,
+            founder_count=0,
+            location=company.hq_location,
+        )
+        base_scores.append((entity, company, score, breakdown))
+
+    top_entities = sorted(
+        base_scores,
+        key=lambda item: (-item[2], item[0].rank or 0),
+    )[: request.input.top_company_limit]
+
+    for entity, company, _score, _breakdown in top_entities:
+        founder_request = build_investor_founder_search_request(
+            company=company,
+            investor_input=request.input,
+        )
+        if founder_request is None:
+            founder_ids_by_company[entity.id] = []
+            continue
+
+        person_search_requests += 1
+        founder_payload = person_search(client, founder_request)
+        founders: list[Person] = []
+        for item in extract_results(founder_payload, "person"):
+            founder = upsert_person(session, normalize_person(item))
+            founders.append(founder)
+
+        deduped_ids: list[str] = []
+        seen_ids: set[str] = set()
+        for founder in founders:
+            if founder.id in seen_ids:
+                continue
+            seen_ids.add(founder.id)
+            deduped_ids.append(founder.id)
+            unique_founder_ids.add(founder.id)
+        founder_ids_by_company[entity.id] = deduped_ids
+
+    entity_models: list[SearchRunEntity] = []
+    for entity, company in company_entities:
+        founder_ids = founder_ids_by_company.get(entity.id, [])
+        score, breakdown = score_investor_company(
+            company=company,
+            investor_input=request.input,
+            founder_count=len(founder_ids),
+            location=company.hq_location,
+        )
+        signals = build_investor_signal_summaries(company)
+        for signal in signals:
+            _upsert_company_signal(
+                session=session,
+                company=company,
+                location=company.hq_location,
+                signal_type=signal.signal_type,
+                title=signal.title,
+                description=signal.description,
+                confidence=signal.confidence,
+                occurred_at=signal.occurred_at,
+                raw={"run_id": run.id, **signal.model_dump(mode="json")},
+            )
+
+        breakdown["founder_person_ids"] = founder_ids
+        breakdown["founder_count"] = len(founder_ids)
+        breakdown["enriched_for_founders"] = entity.id in founder_ids_by_company
+        breakdown["top_company_limit"] = request.input.top_company_limit
+        breakdown["signal_types"] = [signal.signal_type for signal in signals]
+        entity.lens_score = score
+        entity.score_breakdown = breakdown
+        entity_models.append(entity)
+        signal_count += len(signals)
+
+    counts = _calculate_result_counts(entity_type="company", entities=entity_models)
+    counts["founders"] = len(unique_founder_ids)
+    counts["founder_companies"] = sum(
+        1 for founder_ids in founder_ids_by_company.values() if founder_ids
+    )
+    counts["signals"] = signal_count
+    return (
+        entity_models,
+        counts,
+        {
+            "company_search_requests": 1,
+            "person_search_requests": person_search_requests,
+        },
+    )
 
 
 def _run_sales_search(
@@ -441,7 +601,7 @@ def create_search_run(
                 request=request,
             )
         elif request.lens == "investor":
-            _entities, result_counts, cost_estimate = _run_company_search(
+            _entities, result_counts, cost_estimate = _run_investor_search(
                 session=session,
                 run=run,
                 client=client,

--- a/app/runs/service.py
+++ b/app/runs/service.py
@@ -12,6 +12,11 @@ from app.crustdata.client import CrustdataClient
 from app.crustdata.company import company_search
 from app.crustdata.person import person_search
 from app.db.models import Company, Location, Person, SearchRun, SearchRunEntity, User
+from app.lenses.recruiting import (
+    RecruitingRunInput,
+    build_recruiting_search_request,
+    score_recruiting_person,
+)
 from app.lenses.sales import SalesRunInput, build_sales_buyer_search_request, score_sales_company
 from app.runs.normalization import (
     NormalizedCompany,
@@ -286,6 +291,46 @@ def _run_person_search(
     return entity_models, counts, {"company_search_requests": 0, "person_search_requests": 1}
 
 
+def _run_recruiting_search(
+    *,
+    session: Session,
+    run: SearchRun,
+    client: CrustdataClient,
+    request: CreateRunRequest,
+) -> tuple[list[SearchRunEntity], dict[str, int | str], dict[str, int]]:
+    if not isinstance(request.input, RecruitingRunInput):
+        raise AppError(
+            code="BAD_INPUT",
+            message="Recruiting runs require recruiting-specific input.",
+            status_code=400,
+        )
+
+    search_request = build_recruiting_search_request(request.input)
+    payload = person_search(client, search_request)
+    entities = _build_person_entities(session=session, run=run, payload=payload)
+
+    employers: set[str] = set()
+    entity_models: list[SearchRunEntity] = []
+    for entity, person in entities:
+        score, breakdown = score_recruiting_person(
+            person=person,
+            recruiting_input=request.input,
+            location=person.location,
+        )
+        breakdown["top_candidate_limit"] = request.input.top_candidate_limit
+        entity.lens_score = score
+        entity.score_breakdown = breakdown
+        entity_models.append(entity)
+
+        employer_key = person.current_company_domain or person.current_company_name
+        if employer_key:
+            employers.add(employer_key)
+
+    counts = _calculate_result_counts(entity_type="person", entities=entity_models)
+    counts["employers"] = len(employers)
+    return entity_models, counts, {"company_search_requests": 0, "person_search_requests": 1}
+
+
 def _run_sales_search(
     *,
     session: Session,
@@ -397,6 +442,13 @@ def create_search_run(
             )
         elif request.lens == "investor":
             _entities, result_counts, cost_estimate = _run_company_search(
+                session=session,
+                run=run,
+                client=client,
+                request=request,
+            )
+        elif request.lens == "recruiting":
+            _entities, result_counts, cost_estimate = _run_recruiting_search(
                 session=session,
                 run=run,
                 client=client,

--- a/app/runs/service.py
+++ b/app/runs/service.py
@@ -12,6 +12,7 @@ from app.crustdata.client import CrustdataClient
 from app.crustdata.company import company_search
 from app.crustdata.person import person_search
 from app.db.models import Company, Location, Person, SearchRun, SearchRunEntity, User
+from app.lenses.sales import SalesRunInput, build_sales_buyer_search_request, score_sales_company
 from app.runs.normalization import (
     NormalizedCompany,
     NormalizedLocation,
@@ -209,6 +210,170 @@ def _build_run(request: CreateRunRequest, user: User) -> SearchRun:
     )
 
 
+def _build_company_entities(
+    *,
+    session: Session,
+    run: SearchRun,
+    payload: dict,
+) -> list[tuple[SearchRunEntity, Company]]:
+    raw_results = extract_results(payload, "company")
+    entities: list[tuple[SearchRunEntity, Company]] = []
+    for rank, item in enumerate(raw_results, start=1):
+        company = upsert_company(session, normalize_company(item))
+        entity = SearchRunEntity(
+            run_id=run.id,
+            entity_type="company",
+            company_id=company.id,
+            location_id=company.hq_location_id,
+            rank=rank,
+            lens_score=0.0,
+            score_breakdown={},
+        )
+        session.add(entity)
+        entities.append((entity, company))
+    return entities
+
+
+def _build_person_entities(
+    *,
+    session: Session,
+    run: SearchRun,
+    payload: dict,
+) -> list[tuple[SearchRunEntity, Person]]:
+    raw_results = extract_results(payload, "person")
+    entities: list[tuple[SearchRunEntity, Person]] = []
+    for rank, item in enumerate(raw_results, start=1):
+        person = upsert_person(session, normalize_person(item))
+        entity = SearchRunEntity(
+            run_id=run.id,
+            entity_type="person",
+            person_id=person.id,
+            location_id=person.location_id,
+            rank=rank,
+            lens_score=0.0,
+            score_breakdown={},
+        )
+        session.add(entity)
+        entities.append((entity, person))
+    return entities
+
+
+def _run_company_search(
+    *,
+    session: Session,
+    run: SearchRun,
+    client: CrustdataClient,
+    request: CreateRunRequest,
+) -> tuple[list[SearchRunEntity], dict[str, int | str], dict[str, int]]:
+    payload = company_search(client, request.input.search)
+    entities = _build_company_entities(session=session, run=run, payload=payload)
+    entity_models = [entity for entity, _company in entities]
+    counts = _calculate_result_counts(entity_type="company", entities=entity_models)
+    return entity_models, counts, {"company_search_requests": 1, "person_search_requests": 0}
+
+
+def _run_person_search(
+    *,
+    session: Session,
+    run: SearchRun,
+    client: CrustdataClient,
+    request: CreateRunRequest,
+) -> tuple[list[SearchRunEntity], dict[str, int | str], dict[str, int]]:
+    payload = person_search(client, request.input.search)
+    entities = _build_person_entities(session=session, run=run, payload=payload)
+    entity_models = [entity for entity, _person in entities]
+    counts = _calculate_result_counts(entity_type="person", entities=entity_models)
+    return entity_models, counts, {"company_search_requests": 0, "person_search_requests": 1}
+
+
+def _run_sales_search(
+    *,
+    session: Session,
+    run: SearchRun,
+    client: CrustdataClient,
+    request: CreateRunRequest,
+) -> tuple[list[SearchRunEntity], dict[str, int | str], dict[str, int]]:
+    if not isinstance(request.input, SalesRunInput):
+        raise AppError(
+            code="BAD_INPUT",
+            message="Sales runs require sales-specific input.",
+            status_code=400,
+        )
+
+    payload = company_search(client, request.input.search)
+    company_entities = _build_company_entities(session=session, run=run, payload=payload)
+
+    buyer_ids_by_company: dict[str, list[str]] = {}
+    person_search_requests = 0
+    unique_buyer_ids: set[str] = set()
+
+    base_scores: dict[str, tuple[float, dict]] = {}
+    for entity, company in company_entities:
+        score, breakdown = score_sales_company(
+            company=company,
+            sales_input=request.input,
+            buyer_count=0,
+            location=company.hq_location,
+        )
+        base_scores[entity.id] = (score, breakdown)
+
+    top_entities = sorted(
+        company_entities,
+        key=lambda item: (-base_scores[item[0].id][0], item[0].rank or 0),
+    )[: request.input.top_company_limit]
+
+    for entity, company in top_entities:
+        buyer_request = build_sales_buyer_search_request(company=company, sales_input=request.input)
+        if buyer_request is None:
+            buyer_ids_by_company[entity.id] = []
+            continue
+
+        person_search_requests += 1
+        buyer_payload = person_search(client, buyer_request)
+        buyers: list[Person] = []
+        for item in extract_results(buyer_payload, "person"):
+            person = upsert_person(session, normalize_person(item))
+            buyers.append(person)
+
+        deduped_ids: list[str] = []
+        seen_ids: set[str] = set()
+        for buyer in buyers:
+            if buyer.id in seen_ids:
+                continue
+            seen_ids.add(buyer.id)
+            deduped_ids.append(buyer.id)
+            unique_buyer_ids.add(buyer.id)
+        buyer_ids_by_company[entity.id] = deduped_ids
+
+    entity_models: list[SearchRunEntity] = []
+    for entity, company in company_entities:
+        buyer_ids = buyer_ids_by_company.get(entity.id, [])
+        score, breakdown = score_sales_company(
+            company=company,
+            sales_input=request.input,
+            buyer_count=len(buyer_ids),
+            location=company.hq_location,
+        )
+        breakdown["buyer_person_ids"] = buyer_ids
+        breakdown["buyer_count"] = len(buyer_ids)
+        breakdown["enriched_for_buyers"] = entity.id in buyer_ids_by_company
+        entity.lens_score = score
+        entity.score_breakdown = breakdown
+        entity_models.append(entity)
+
+    counts = _calculate_result_counts(entity_type="company", entities=entity_models)
+    counts["buyers"] = len(unique_buyer_ids)
+    counts["buyer_companies"] = sum(1 for buyer_ids in buyer_ids_by_company.values() if buyer_ids)
+    return (
+        entity_models,
+        counts,
+        {
+            "company_search_requests": 1,
+            "person_search_requests": person_search_requests,
+        },
+    )
+
+
 def create_search_run(
     *,
     session: Session,
@@ -223,47 +388,30 @@ def create_search_run(
     run_id = run.id
 
     try:
-        if request.lens in {"sales", "investor"}:
-            payload = company_search(client, request.input.search)
-            raw_results = extract_results(payload, "company")
-            entities = []
-            for rank, item in enumerate(raw_results, start=1):
-                company = upsert_company(session, normalize_company(item))
-                entity = SearchRunEntity(
-                    run_id=run.id,
-                    entity_type="company",
-                    company_id=company.id,
-                    location_id=company.hq_location_id,
-                    rank=rank,
-                    lens_score=0.0,
-                    score_breakdown={},
-                )
-                session.add(entity)
-                entities.append(entity)
-            primary_entity_type = "company"
+        if request.lens == "sales":
+            _entities, result_counts, cost_estimate = _run_sales_search(
+                session=session,
+                run=run,
+                client=client,
+                request=request,
+            )
+        elif request.lens == "investor":
+            _entities, result_counts, cost_estimate = _run_company_search(
+                session=session,
+                run=run,
+                client=client,
+                request=request,
+            )
         else:
-            payload = person_search(client, request.input.search)
-            raw_results = extract_results(payload, "person")
-            entities = []
-            for rank, item in enumerate(raw_results, start=1):
-                person = upsert_person(session, normalize_person(item))
-                entity = SearchRunEntity(
-                    run_id=run.id,
-                    entity_type="person",
-                    person_id=person.id,
-                    location_id=person.location_id,
-                    rank=rank,
-                    lens_score=0.0,
-                    score_breakdown={},
-                )
-                session.add(entity)
-                entities.append(entity)
-            primary_entity_type = "person"
+            _entities, result_counts, cost_estimate = _run_person_search(
+                session=session,
+                run=run,
+                client=client,
+                request=request,
+            )
 
-        run.result_counts = _calculate_result_counts(
-            entity_type=primary_entity_type,
-            entities=entities,
-        )
+        run.result_counts = result_counts
+        run.cost_estimate = cost_estimate
         run.status = "complete"
         run.completed_at = _utcnow()
         session.commit()

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -83,6 +83,11 @@ def test_run_clusters_group_entities_by_location(client, monkeypatch):
             ]
         },
     )
+    monkeypatch.setattr(
+        run_service,
+        "person_search",
+        lambda _client, _request: {"results": []},
+    )
 
     create_response = client.post(
         "/api/runs",

--- a/tests/test_investor.py
+++ b/tests/test_investor.py
@@ -1,0 +1,260 @@
+from __future__ import annotations
+
+from app.api.deps import get_geocoder
+from app.geo.geocode import GeocodeResult, StaticGeocoder
+from app.main import app
+from app.runs import service as run_service
+
+
+def test_investor_run_builds_filters_and_summary(client, monkeypatch):
+    geocoder = StaticGeocoder(
+        {
+            "san francisco, california, united states": GeocodeResult(
+                status="mapped",
+                latitude=37.7749,
+                longitude=-122.4194,
+                precision="city",
+                confidence=0.95,
+                provider="static",
+            ),
+            "new york, new york, united states": GeocodeResult(
+                status="mapped",
+                latitude=40.7128,
+                longitude=-74.006,
+                precision="city",
+                confidence=0.94,
+                provider="static",
+            ),
+        }
+    )
+    app.dependency_overrides[get_geocoder] = lambda: geocoder
+
+    captured_company_request: dict[str, object] = {}
+    founder_search_domains: list[str] = []
+
+    def fake_company_search(_client, request):
+        captured_company_request["payload"] = request.model_dump(exclude_none=True)
+        return {
+            "results": [
+                {
+                    "crustdata_company_id": "cmp-1",
+                    "basic_info": {
+                        "name": "Bravo Robotics",
+                        "primary_domain": "bravo.com",
+                        "website": "https://bravo.com",
+                        "company_type": "private",
+                        "year_founded": 2017,
+                        "markets": ["Industrial Automation"],
+                    },
+                    "taxonomy": {
+                        "professional_network_industry": "Manufacturing",
+                        "categories": ["Robotics"],
+                    },
+                    "headcount": {"total": 60},
+                    "funding": {
+                        "total_investment_usd": 500000,
+                        "last_round_type": "pre_seed",
+                        "last_round_amount_usd": 500000,
+                        "last_fundraise_date": "2021-02-01",
+                    },
+                    "followers": {"six_months_growth_percent": 4},
+                    "hiring": {"openings_count": 1, "openings_growth_percent": -5},
+                    "roles": {"growth_6m": 3},
+                    "locations": {
+                        "headquarters": "New York, New York, United States",
+                        "hq_city": "New York",
+                        "hq_state": "New York",
+                        "hq_country": "United States",
+                    },
+                },
+                {
+                    "crustdata_company_id": "cmp-2",
+                    "basic_info": {
+                        "name": "Acme AI",
+                        "primary_domain": "acme.com",
+                        "website": "https://acme.com",
+                        "company_type": "private",
+                        "year_founded": 2021,
+                        "markets": ["AI Infrastructure", "Developer Tools"],
+                    },
+                    "taxonomy": {
+                        "professional_network_industry": "Software",
+                        "categories": ["Developer Tools", "Artificial Intelligence"],
+                    },
+                    "headcount": {"total": 120},
+                    "funding": {
+                        "total_investment_usd": 32000000,
+                        "last_round_type": "series_a",
+                        "last_round_amount_usd": 15000000,
+                        "last_fundraise_date": "2025-08-01",
+                    },
+                    "followers": {"six_months_growth_percent": 62},
+                    "hiring": {"openings_count": 24, "openings_growth_percent": 135},
+                    "roles": {"growth_6m": 48},
+                    "locations": {
+                        "headquarters": "San Francisco, California, United States",
+                        "hq_city": "San Francisco",
+                        "hq_state": "California",
+                        "hq_country": "United States",
+                    },
+                },
+            ]
+        }
+
+    monkeypatch.setattr(run_service, "company_search", fake_company_search)
+
+    def fake_person_search(_client, request):
+        payload = request.model_dump(exclude_none=True)
+        filters = payload["filters"]
+        domain = filters["conditions"][0]["value"]
+        founder_search_domains.append(domain)
+        if domain == "acme.com":
+            return {
+                "results": [
+                    {
+                        "crustdata_person_id": "prs-1",
+                        "basic_profile": {
+                            "name": "Jane Founder",
+                            "headline": "Founder building AI developer tooling",
+                        },
+                        "experience": {
+                            "employment_details": {
+                                "current": {
+                                    "title": "Founder",
+                                    "company_name": "Acme AI",
+                                    "company_website_domain": "acme.com",
+                                    "seniority_level": "cxo",
+                                }
+                            }
+                        },
+                        "social_handles": {
+                            "professional_network_identifier": {
+                                "profile_url": "https://linkedin.com/in/jane-founder"
+                            }
+                        },
+                    },
+                    {
+                        "crustdata_person_id": "prs-2",
+                        "basic_profile": {
+                            "name": "Sam CEO",
+                            "headline": "CEO scaling AI infrastructure",
+                        },
+                        "experience": {
+                            "employment_details": {
+                                "current": {
+                                    "title": "CEO",
+                                    "company_name": "Acme AI",
+                                    "company_website_domain": "acme.com",
+                                    "seniority_level": "cxo",
+                                }
+                            }
+                        },
+                        "social_handles": {
+                            "professional_network_identifier": {
+                                "profile_url": "https://linkedin.com/in/sam-ceo"
+                            }
+                        },
+                    },
+                ]
+            }
+        return {"results": []}
+
+    monkeypatch.setattr(run_service, "person_search", fake_person_search)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "lens": "investor",
+            "title": "Investor engine run",
+            "input": {
+                "search": {
+                    "fields": ["basic_info.name"],
+                    "limit": 10,
+                },
+                "target_markets": ["AI Infrastructure"],
+                "target_categories": ["Developer Tools"],
+                "min_openings_growth_percent": 20,
+                "top_company_limit": 1,
+                "founders_per_company": 2,
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["result_counts"]["companies"] == 2
+    assert payload["result_counts"]["founders"] == 2
+    assert payload["result_counts"]["founder_companies"] == 1
+    assert payload["result_counts"]["signals"] == 6
+    assert founder_search_domains == ["acme.com"]
+
+    search_payload = captured_company_request["payload"]
+    assert isinstance(search_payload, dict)
+    assert "filters" in search_payload
+    filters = search_payload["filters"]
+    assert isinstance(filters, dict)
+    assert filters["op"] == "and"
+    conditions = filters["conditions"]
+    assert isinstance(conditions, list)
+    fields = {condition["field"] for condition in conditions}
+    assert "basic_info.markets" in fields
+    assert "taxonomy.categories" in fields
+    assert "hiring.openings_growth_percent" in fields
+
+    run_id = payload["run_id"]
+    summary_response = client.get(f"/api/runs/{run_id}/investor-summary")
+    assert summary_response.status_code == 200
+    summary_payload = summary_response.json()
+    assert summary_payload["summary"]["company_count"] == 2
+    assert summary_payload["summary"]["mapped_company_count"] == 2
+    assert summary_payload["summary"]["founder_count"] == 2
+    assert summary_payload["summary"]["signal_count"] == 6
+    assert summary_payload["companies"][0]["name"] == "Acme AI"
+    assert summary_payload["companies"][0]["founder_count"] == 2
+    assert summary_payload["companies"][0]["founders"][0]["name"] == "Jane Founder"
+    assert (
+        summary_payload["companies"][0]["lens_score"]
+        > summary_payload["companies"][1]["lens_score"]
+    )
+    signal_types = {signal["signal_type"] for signal in summary_payload["companies"][0]["signals"]}
+    assert signal_types == {"funding", "hiring", "headcount"}
+
+
+def test_investor_summary_rejects_non_investor_runs(client, monkeypatch):
+    monkeypatch.setattr(
+        run_service,
+        "company_search",
+        lambda _client, _request: {
+            "results": [
+                {
+                    "crustdata_company_id": "cmp-11",
+                    "basic_info": {"name": "Acme", "primary_domain": "acme.com"},
+                    "locations": {"headquarters": "San Francisco, California, United States"},
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        run_service,
+        "person_search",
+        lambda _client, _request: {"results": []},
+    )
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "lens": "sales",
+            "input": {
+                "search": {
+                    "fields": ["basic_info.name", "basic_info.primary_domain"],
+                    "limit": 10,
+                }
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    run_id = response.json()["run_id"]
+    summary_response = client.get(f"/api/runs/{run_id}/investor-summary")
+    assert summary_response.status_code == 400
+    assert summary_response.json()["error"]["code"] == "BAD_INPUT"

--- a/tests/test_recruiting.py
+++ b/tests/test_recruiting.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+from app.api.deps import get_geocoder
+from app.geo.geocode import GeocodeResult, StaticGeocoder
+from app.main import app
+from app.runs import service as run_service
+
+
+def test_recruiting_run_builds_filters_and_summary(client, monkeypatch):
+    geocoder = StaticGeocoder(
+        {
+            "bengaluru, karnataka, india": GeocodeResult(
+                status="mapped",
+                latitude=12.9716,
+                longitude=77.5946,
+                precision="city",
+                confidence=0.92,
+                provider="static",
+            ),
+            "mumbai, maharashtra, india": GeocodeResult(
+                status="mapped",
+                latitude=19.076,
+                longitude=72.8777,
+                precision="city",
+                confidence=0.9,
+                provider="static",
+            ),
+        }
+    )
+    app.dependency_overrides[get_geocoder] = lambda: geocoder
+
+    captured_request: dict[str, object] = {}
+
+    def fake_person_search(_client, request):
+        captured_request["payload"] = request.model_dump(exclude_none=True)
+        return {
+            "results": [
+                {
+                    "crustdata_person_id": "prs-1",
+                    "basic_profile": {
+                        "name": "Jane Doe",
+                        "headline": "VP Engineering | Python platform leader",
+                        "location": {
+                            "city": "Bengaluru",
+                            "state": "Karnataka",
+                            "country": "India",
+                            "full_location": "Bengaluru, Karnataka, India",
+                        },
+                    },
+                    "experience": {
+                        "employment_details": {
+                            "current": {
+                                "title": "VP Engineering",
+                                "company_name": "Acme",
+                                "company_website_domain": "acme.com",
+                                "seniority_level": "vp",
+                                "function_category": "engineering",
+                            }
+                        }
+                    },
+                    "contact": {"has_business_email": True, "has_phone_number": True},
+                    "social_handles": {
+                        "professional_network_identifier": {
+                            "profile_url": "https://linkedin.com/in/jane-doe"
+                        }
+                    },
+                },
+                {
+                    "crustdata_person_id": "prs-2",
+                    "basic_profile": {
+                        "name": "John Roe",
+                        "headline": "Engineering Manager building cloud systems",
+                        "location": {
+                            "city": "Bengaluru",
+                            "state": "Karnataka",
+                            "country": "India",
+                            "full_location": "Bengaluru, Karnataka, India",
+                        },
+                    },
+                    "experience": {
+                        "employment_details": {
+                            "current": {
+                                "title": "Engineering Manager",
+                                "company_name": "Bravo",
+                                "company_website_domain": "bravo.com",
+                                "seniority_level": "director",
+                                "function_category": "engineering",
+                            }
+                        }
+                    },
+                    "contact": {"has_phone_number": True},
+                    "social_handles": {
+                        "professional_network_identifier": {
+                            "profile_url": "https://linkedin.com/in/john-roe"
+                        }
+                    },
+                },
+                {
+                    "crustdata_person_id": "prs-3",
+                    "basic_profile": {
+                        "name": "Priya Patel",
+                        "headline": "Talent partner",
+                        "location": {
+                            "city": "Mumbai",
+                            "state": "Maharashtra",
+                            "country": "India",
+                            "full_location": "Mumbai, Maharashtra, India",
+                        },
+                    },
+                    "experience": {
+                        "employment_details": {
+                            "current": {
+                                "title": "Recruiter",
+                                "company_name": "Acme",
+                                "company_website_domain": "acme.com",
+                                "seniority_level": "manager",
+                                "function_category": "people",
+                            }
+                        }
+                    },
+                    "contact": {"has_personal_email": True},
+                    "social_handles": {
+                        "professional_network_identifier": {
+                            "profile_url": "https://linkedin.com/in/priya-patel"
+                        }
+                    },
+                },
+            ]
+        }
+
+    monkeypatch.setattr(run_service, "person_search", fake_person_search)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "lens": "recruiting",
+            "title": "Recruiting engine run",
+            "input": {
+                "search": {
+                    "fields": ["basic_profile.name"],
+                    "limit": 10,
+                },
+                "target_titles": ["Engineering", "VP"],
+                "target_seniorities": ["vp", "director"],
+                "target_functions": ["engineering"],
+                "target_skills": ["Python"],
+                "radius": {
+                    "latitude": 12.9716,
+                    "longitude": 77.5946,
+                    "radius_km": 50,
+                },
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["result_counts"]["people"] == 3
+    assert payload["result_counts"]["employers"] == 2
+
+    search_payload = captured_request["payload"]
+    assert isinstance(search_payload, dict)
+    assert "filters" in search_payload
+    filters = search_payload["filters"]
+    assert isinstance(filters, dict)
+    assert filters["op"] == "and"
+    conditions = filters["conditions"]
+    assert isinstance(conditions, list)
+    fields = {condition["field"] for condition in conditions}
+    assert "experience.employment_details.current.title" in fields
+    assert "experience.employment_details.current.seniority_level" in fields
+    assert "experience.employment_details.current.function_category" in fields
+    assert "basic_profile.headline" in fields
+    assert "basic_profile.location" in fields
+
+    run_id = payload["run_id"]
+    summary_response = client.get(f"/api/runs/{run_id}/recruiting-summary")
+    assert summary_response.status_code == 200
+    summary_payload = summary_response.json()
+    assert summary_payload["summary"]["people_count"] == 3
+    assert summary_payload["summary"]["mapped_people_count"] == 3
+    assert summary_payload["summary"]["employer_count"] == 2
+    assert summary_payload["candidates"][0]["name"] == "Jane Doe"
+    assert (
+        summary_payload["candidates"][0]["lens_score"]
+        > summary_payload["candidates"][1]["lens_score"]
+    )
+    assert summary_payload["locations"][0]["raw_label"] == "Bengaluru, Karnataka, India"
+    assert summary_payload["locations"][0]["people_count"] == 2
+    assert summary_payload["locations"][0]["employer_count"] == 2
+
+
+def test_recruiting_summary_rejects_non_recruiting_runs(client, monkeypatch):
+    monkeypatch.setattr(
+        run_service,
+        "company_search",
+        lambda _client, _request: {
+            "results": [
+                {
+                    "crustdata_company_id": "cmp-11",
+                    "basic_info": {"name": "Acme", "primary_domain": "acme.com"},
+                    "locations": {"headquarters": "Bengaluru, Karnataka, India"},
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        run_service,
+        "person_search",
+        lambda _client, _request: {"results": []},
+    )
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "lens": "sales",
+            "input": {
+                "search": {
+                    "fields": ["basic_info.name", "basic_info.primary_domain"],
+                    "limit": 10,
+                }
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    run_id = response.json()["run_id"]
+    summary_response = client.get(f"/api/runs/{run_id}/recruiting-summary")
+    assert summary_response.status_code == 400
+    assert summary_response.json()["error"]["code"] == "BAD_INPUT"

--- a/tests/test_recruiting.py
+++ b/tests/test_recruiting.py
@@ -144,6 +144,7 @@ def test_recruiting_run_builds_filters_and_summary(client, monkeypatch):
                 "target_seniorities": ["vp", "director"],
                 "target_functions": ["engineering"],
                 "target_skills": ["Python"],
+                "top_candidate_limit": 2,
                 "radius": {
                     "latitude": 12.9716,
                     "longitude": 77.5946,
@@ -180,6 +181,7 @@ def test_recruiting_run_builds_filters_and_summary(client, monkeypatch):
     assert summary_payload["summary"]["people_count"] == 3
     assert summary_payload["summary"]["mapped_people_count"] == 3
     assert summary_payload["summary"]["employer_count"] == 2
+    assert len(summary_payload["candidates"]) == 2
     assert summary_payload["candidates"][0]["name"] == "Jane Doe"
     assert (
         summary_payload["candidates"][0]["lens_score"]
@@ -188,6 +190,11 @@ def test_recruiting_run_builds_filters_and_summary(client, monkeypatch):
     assert summary_payload["locations"][0]["raw_label"] == "Bengaluru, Karnataka, India"
     assert summary_payload["locations"][0]["people_count"] == 2
     assert summary_payload["locations"][0]["employer_count"] == 2
+
+    override_response = client.get(f"/api/runs/{run_id}/recruiting-summary?limit=3")
+    assert override_response.status_code == 200
+    override_payload = override_response.json()
+    assert len(override_payload["candidates"]) == 3
 
 
 def test_recruiting_summary_rejects_non_recruiting_runs(client, monkeypatch):

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -30,6 +30,11 @@ def test_create_sales_run_persists_companies_and_locations(client, monkeypatch):
             ]
         },
     )
+    monkeypatch.setattr(
+        run_service,
+        "person_search",
+        lambda _client, _request: {"results": []},
+    )
 
     response = client.post(
         "/api/runs",
@@ -50,6 +55,7 @@ def test_create_sales_run_persists_companies_and_locations(client, monkeypatch):
     assert payload["status"] == "complete"
     assert payload["lens"] == "sales"
     assert payload["result_counts"]["companies"] == 1
+    assert payload["result_counts"]["buyers"] == 0
     assert payload["result_counts"]["locations"] == 1
 
     run_id = payload["run_id"]

--- a/tests/test_sales.py
+++ b/tests/test_sales.py
@@ -216,3 +216,21 @@ def test_sales_summary_rejects_non_sales_runs(client, monkeypatch):
     summary_response = client.get(f"/api/runs/{run_id}/sales-summary")
     assert summary_response.status_code == 400
     assert summary_response.json()["error"]["code"] == "BAD_INPUT"
+
+
+def test_sales_run_rejects_empty_buyer_fields(client):
+    response = client.post(
+        "/api/runs",
+        json={
+            "lens": "sales",
+            "input": {
+                "search": {
+                    "fields": ["basic_info.name", "basic_info.primary_domain"],
+                    "limit": 10,
+                },
+                "buyer_fields": [],
+            },
+        },
+    )
+
+    assert response.status_code == 422

--- a/tests/test_sales.py
+++ b/tests/test_sales.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+from app.api.deps import get_geocoder
+from app.geo.geocode import GeocodeResult, StaticGeocoder
+from app.main import app
+from app.runs import service as run_service
+
+
+def test_sales_run_attaches_buyers_and_summary_cards(client, monkeypatch):
+    geocoder = StaticGeocoder(
+        {
+            "san francisco, california, united states": GeocodeResult(
+                status="mapped",
+                latitude=37.7749,
+                longitude=-122.4194,
+                precision="city",
+                confidence=0.95,
+                provider="static",
+            )
+        }
+    )
+    app.dependency_overrides[get_geocoder] = lambda: geocoder
+
+    monkeypatch.setattr(
+        run_service,
+        "company_search",
+        lambda _client, _request: {
+            "results": [
+                {
+                    "crustdata_company_id": "cmp-1",
+                    "basic_info": {
+                        "name": "Acme",
+                        "primary_domain": "acme.com",
+                        "company_type": "private",
+                        "year_founded": 2018,
+                    },
+                    "taxonomy": {"professional_network_industry": "Software"},
+                    "headcount": {"total": 180},
+                    "funding": {
+                        "total_investment_usd": 25000000,
+                        "last_round_type": "series_a",
+                        "last_round_amount_usd": 12000000,
+                        "last_fundraise_date": "2025-05-01",
+                    },
+                    "locations": {
+                        "headquarters": "San Francisco, California, United States",
+                        "hq_city": "San Francisco",
+                        "hq_state": "California",
+                        "hq_country": "United States",
+                    },
+                },
+                {
+                    "crustdata_company_id": "cmp-2",
+                    "basic_info": {
+                        "name": "Bravo",
+                        "primary_domain": "bravo.com",
+                        "company_type": "private",
+                        "year_founded": 2012,
+                    },
+                    "taxonomy": {"professional_network_industry": "Manufacturing"},
+                    "headcount": {"total": 4500},
+                    "funding": {
+                        "total_investment_usd": 0,
+                    },
+                    "locations": {
+                        "headquarters": "San Francisco, California, United States",
+                        "hq_city": "San Francisco",
+                        "hq_state": "California",
+                        "hq_country": "United States",
+                    },
+                },
+            ]
+        },
+    )
+
+    def fake_person_search(_client, request):
+        filters = request.model_dump(exclude_none=True)["filters"]
+        domain = filters["conditions"][0]["value"]
+        if domain == "acme.com":
+            return {
+                "results": [
+                    {
+                        "crustdata_person_id": "prs-1",
+                        "basic_profile": {
+                            "name": "Alice Seller",
+                            "headline": "VP Sales at Acme",
+                            "location": {
+                                "city": "San Francisco",
+                                "state": "California",
+                                "country": "United States",
+                                "full_location": "San Francisco, California, United States",
+                            },
+                        },
+                        "experience": {
+                            "employment_details": {
+                                "current": {
+                                    "title": "VP Sales",
+                                    "company_name": "Acme",
+                                    "company_website_domain": "acme.com",
+                                    "seniority_level": "vp",
+                                    "function_category": "sales",
+                                }
+                            }
+                        },
+                        "contact": {"has_business_email": True},
+                        "social_handles": {
+                            "professional_network_identifier": {
+                                "profile_url": "https://linkedin.com/in/alice-seller"
+                            }
+                        },
+                    },
+                    {
+                        "crustdata_person_id": "prs-2",
+                        "basic_profile": {
+                            "name": "Bob Founder",
+                            "headline": "Founder at Acme",
+                            "location": {
+                                "city": "San Francisco",
+                                "state": "California",
+                                "country": "United States",
+                                "full_location": "San Francisco, California, United States",
+                            },
+                        },
+                        "experience": {
+                            "employment_details": {
+                                "current": {
+                                    "title": "Founder",
+                                    "company_name": "Acme",
+                                    "company_website_domain": "acme.com",
+                                    "seniority_level": "cxo",
+                                    "function_category": "executive",
+                                }
+                            }
+                        },
+                        "contact": {"has_business_email": True},
+                        "social_handles": {
+                            "professional_network_identifier": {
+                                "profile_url": "https://linkedin.com/in/bob-founder"
+                            }
+                        },
+                    },
+                ]
+            }
+        return {"results": []}
+
+    monkeypatch.setattr(run_service, "person_search", fake_person_search)
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "lens": "sales",
+            "title": "Sales engine run",
+            "input": {
+                "search": {
+                    "fields": ["basic_info.name", "basic_info.primary_domain"],
+                    "limit": 10,
+                },
+                "preferred_industries": ["Software"],
+                "top_company_limit": 1,
+                "buyers_per_company": 2,
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["result_counts"]["companies"] == 2
+    assert payload["result_counts"]["buyers"] == 2
+    assert payload["result_counts"]["buyer_companies"] == 1
+
+    run_id = payload["run_id"]
+    summary_response = client.get(f"/api/runs/{run_id}/sales-summary")
+    assert summary_response.status_code == 200
+    summary_payload = summary_response.json()
+    assert summary_payload["summary"]["company_count"] == 2
+    assert summary_payload["summary"]["buyer_count"] == 2
+    assert summary_payload["companies"][0]["name"] == "Acme"
+    assert summary_payload["companies"][0]["buyer_count"] == 2
+    assert summary_payload["companies"][0]["buyers"][0]["name"] == "Alice Seller"
+    assert (
+        summary_payload["companies"][0]["lens_score"]
+        > summary_payload["companies"][1]["lens_score"]
+    )
+    assert summary_payload["companies"][0]["score_breakdown"]["buyer_count"] == 2
+
+
+def test_sales_summary_rejects_non_sales_runs(client, monkeypatch):
+    monkeypatch.setattr(
+        run_service,
+        "person_search",
+        lambda _client, _request: {
+            "results": [
+                {
+                    "crustdata_person_id": "prs-9",
+                    "basic_profile": {"name": "Jane Doe"},
+                }
+            ]
+        },
+    )
+
+    response = client.post(
+        "/api/runs",
+        json={
+            "lens": "recruiting",
+            "input": {
+                "search": {
+                    "fields": ["basic_profile.name"],
+                    "limit": 10,
+                }
+            },
+        },
+    )
+
+    assert response.status_code == 200
+    run_id = response.json()["run_id"]
+    summary_response = client.get(f"/api/runs/{run_id}/sales-summary")
+    assert summary_response.status_code == 400
+    assert summary_response.json()["error"]["code"] == "BAD_INPUT"


### PR DESCRIPTION
## What changed
This PR brings the next backend product phases onto `main` in one reviewable stack:

- Phase 5: Sales engine
- Phase 6: Recruiting engine
- Phase 7: Investor engine
- follow-up fixes for the two confirmed regressions in Sales and Recruiting

## Why it changed
The goal was to finish the backend lens engine before starting frontend work. That meant landing the commercial search flows first and keeping the UI deferred.

The regression fix commit is included because two contract issues were confirmed during review:

- invalid Sales `buyer_fields` could surface as a `500`
- Recruiting `top_candidate_limit` was stored but not actually used by the summary route

## User and developer impact
Backend capabilities now include:

- Sales runs with buyer/persona enrichment for top companies
- Recruiting runs with title, seniority, function, skill, and radius filters plus candidate scoring and employer-by-location summaries
- Investor runs with company-first momentum scoring, founder/executive enrichment, and extracted funding, hiring, and headcount signals

This keeps the product core in Python and gives the future frontend stable summary endpoints to consume.

## Root cause for the fixes
- Sales allowed an empty `buyer_fields` list to pass schema validation, then failed later when constructing the person search request.
- Recruiting had `top_candidate_limit` in run input, but the summary route always defaulted to its own query limit instead of the run configuration.

## Validation
- `uv run --with ruff ruff check .`
- `uv run pytest`
- current test suite passes with `32 passed`
