### PR TITLE
Phase 4: frontend shell

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -7,11 +7,14 @@ from uuid import uuid4
 import uvicorn
 from fastapi import FastAPI, Request
 from fastapi.responses import JSONResponse
+from fastapi.staticfiles import StaticFiles
 
 from app.api.router import api_router
 from app.core.config import get_settings
 from app.core.errors import AppError, app_error_handler, unhandled_exception_handler
 from app.core.logging import configure_logging
+from app.ui.routes import get_ui_assets_dir
+from app.ui.routes import router as ui_router
 
 logger = logging.getLogger("locus.http")
 
@@ -28,6 +31,8 @@ def create_app() -> FastAPI:
 
     application.add_exception_handler(AppError, app_error_handler)
     application.add_exception_handler(Exception, unhandled_exception_handler)
+    application.mount("/ui", StaticFiles(directory=str(get_ui_assets_dir())), name="ui")
+    application.include_router(ui_router)
     application.include_router(api_router)
 
     @application.middleware("http")

--- a/app/ui/__init__.py
+++ b/app/ui/__init__.py
@@ -1,0 +1,1 @@
+"""Frontend shell assets and routes for the Locus workbench."""

--- a/app/ui/assets/app.js
+++ b/app/ui/assets/app.js
@@ -1,0 +1,1212 @@
+const DEFAULT_FIELDS = {
+  sales: [
+    "basic_info.name",
+    "basic_info.primary_domain",
+    "basic_info.website",
+    "taxonomy.professional_network_industry",
+    "headcount.total",
+    "funding.total_investment_usd",
+    "funding.last_round_type",
+    "funding.last_fundraise_date",
+    "locations.headquarters",
+  ],
+  recruiting: [
+    "basic_profile.name",
+    "basic_profile.headline",
+    "basic_profile.location",
+    "experience.employment_details.current.title",
+    "experience.employment_details.current.company_name",
+    "experience.employment_details.current.company_website_domain",
+    "experience.employment_details.current.seniority_level",
+    "experience.employment_details.current.function_category",
+    "contact.has_business_email",
+    "contact.has_phone_number",
+    "social_handles.professional_network_identifier.profile_url",
+  ],
+  investor: [
+    "basic_info.name",
+    "basic_info.primary_domain",
+    "basic_info.website",
+    "basic_info.markets",
+    "taxonomy.categories",
+    "taxonomy.professional_network_industry",
+    "headcount.total",
+    "funding.total_investment_usd",
+    "funding.last_round_type",
+    "funding.last_fundraise_date",
+    "followers.six_months_growth_percent",
+    "hiring.openings_growth_percent",
+    "roles.growth_6m",
+    "locations.headquarters",
+  ],
+};
+
+const STORAGE_KEYS = {
+  lens: "locus.ui.lens",
+  runId: "locus.ui.run",
+  watchlistId: "locus.ui.watchlist",
+};
+
+const state = {
+  lens: window.localStorage.getItem(STORAGE_KEYS.lens) || "sales",
+  auth: null,
+  liveStatus: "Unknown",
+  adminMetrics: null,
+  currentRun: null,
+  summary: null,
+  clusters: null,
+  entities: null,
+  watchlists: [],
+  watchlistSignals: [],
+  selectedWatchlistId: window.localStorage.getItem(STORAGE_KEYS.watchlistId),
+  focusLocationId: null,
+  selectedClusterId: null,
+  entityFilter: "all",
+  isBusy: false,
+  message: "Launching a run will hydrate this shell from the backend state already in the database.",
+};
+
+const refs = {};
+
+document.addEventListener("DOMContentLoaded", () => {
+  init().catch((error) => {
+    console.error(error);
+    setMessage(error.message || "Frontend initialization failed.");
+  });
+});
+
+async function init() {
+  cacheDom();
+  bindEvents();
+  applyLens(state.lens);
+  renderAll();
+
+  await Promise.all([
+    loadAuthContext(),
+    loadServiceHealth(),
+    loadWatchlists({ quiet: true }),
+    loadAdminMetrics(),
+  ]);
+
+  const initialRunId = new URL(window.location.href).searchParams.get("run")
+    || window.localStorage.getItem(STORAGE_KEYS.runId);
+  if (initialRunId) {
+    await loadRun(initialRunId, { announce: false });
+  } else {
+    renderAll();
+  }
+}
+
+function cacheDom() {
+  refs.userBadge = document.querySelector("#userBadge");
+  refs.liveStatus = document.querySelector("#liveStatus");
+  refs.runBadge = document.querySelector("#runBadge");
+  refs.runForm = document.querySelector("#runForm");
+  refs.watchlistForm = document.querySelector("#watchlistForm");
+  refs.heroTitle = document.querySelector("#heroTitle");
+  refs.runMeta = document.querySelector("#runMeta");
+  refs.statGrid = document.querySelector("#statGrid");
+  refs.eventStrip = document.querySelector("#eventStrip");
+  refs.mapSvg = document.querySelector("#mapSvg");
+  refs.mapLegend = document.querySelector("#mapLegend");
+  refs.clusterDetail = document.querySelector("#clusterDetail");
+  refs.summaryBody = document.querySelector("#summaryBody");
+  refs.entityList = document.querySelector("#entityList");
+  refs.entityCountLabel = document.querySelector("#entityCountLabel");
+  refs.watchlistList = document.querySelector("#watchlistList");
+  refs.watchlistBadge = document.querySelector("#watchlistBadge");
+  refs.signalTimeline = document.querySelector("#signalTimeline");
+  refs.lensPills = [...document.querySelectorAll(".lens-pill")];
+  refs.lensPanels = [...document.querySelectorAll("[data-lens-panel]")];
+  refs.entityFilter = document.querySelector("#entityFilter");
+  refs.runButton = document.querySelector("#runButton");
+  refs.reloadRunButton = document.querySelector("#reloadRunButton");
+  refs.refreshWatchlistButton = document.querySelector("#refreshWatchlistButton");
+  refs.resetFocusButton = document.querySelector("#resetFocusButton");
+}
+
+function bindEvents() {
+  refs.lensPills.forEach((button) => {
+    button.addEventListener("click", () => applyLens(button.dataset.lens));
+  });
+
+  refs.runForm.addEventListener("submit", handleRunSubmit);
+  refs.watchlistForm.addEventListener("submit", handleWatchlistCreate);
+  refs.entityFilter.addEventListener("change", handleEntityFilterChange);
+  refs.reloadRunButton.addEventListener("click", handleRunReload);
+  refs.refreshWatchlistButton.addEventListener("click", handleWatchlistRefresh);
+  refs.resetFocusButton.addEventListener("click", handleResetFocus);
+  refs.summaryBody.addEventListener("click", handleActionClick);
+  refs.entityList.addEventListener("click", handleActionClick);
+  refs.watchlistList.addEventListener("click", handleActionClick);
+  refs.mapSvg.addEventListener("click", handleMapClick);
+}
+
+function applyLens(lens) {
+  state.lens = lens;
+  window.localStorage.setItem(STORAGE_KEYS.lens, lens);
+  refs.lensPills.forEach((button) => {
+    button.classList.toggle("active", button.dataset.lens === lens);
+  });
+  refs.lensPanels.forEach((panel) => {
+    const isActive = panel.dataset.lensPanel === lens;
+    panel.hidden = !isActive;
+    panel.classList.toggle("active", isActive);
+  });
+  setMessage(`Lens switched to ${titleCase(lens)}. Tune the search controls and launch a run.`);
+  renderHeader();
+}
+
+async function handleRunSubmit(event) {
+  event.preventDefault();
+  const payload = buildRunPayload();
+  setBusy(true);
+  try {
+    setMessage(`Launching ${titleCase(payload.lens)} run...`);
+    const response = await requestJson("/api/runs", {
+      method: "POST",
+      body: payload,
+    });
+    await loadRun(response.run_id, { announce: true });
+  } finally {
+    setBusy(false);
+  }
+}
+
+async function handleWatchlistCreate(event) {
+  event.preventDefault();
+  const name = refs.watchlistForm.elements.watchlistName.value.trim();
+  if (!name) {
+    setMessage("Watchlist name is required.");
+    return;
+  }
+
+  const description = refs.watchlistForm.elements.watchlistDescription.value.trim();
+  try {
+    setMessage(`Creating watchlist ${name}...`);
+    const watchlist = await requestJson("/api/watchlists", {
+      method: "POST",
+      body: {
+        name,
+        lens: state.lens,
+        description: description || null,
+      },
+    });
+    refs.watchlistForm.reset();
+    state.selectedWatchlistId = watchlist.watchlist_id;
+    window.localStorage.setItem(STORAGE_KEYS.watchlistId, watchlist.watchlist_id);
+    await loadWatchlists();
+    setMessage(`Watchlist ${name} is ready for tracked entities.`);
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+async function handleEntityFilterChange() {
+  state.entityFilter = refs.entityFilter.value;
+  if (!state.currentRun) {
+    renderAll();
+    return;
+  }
+
+  setBusy(true);
+  try {
+    await loadRunSlices(state.currentRun.run_id);
+    setMessage(`Entity filter set to ${state.entityFilter}.`);
+  } finally {
+    setBusy(false);
+  }
+}
+
+async function handleRunReload() {
+  if (!state.currentRun) {
+    setMessage("No run is loaded yet.");
+    return;
+  }
+
+  setBusy(true);
+  try {
+    await loadRun(state.currentRun.run_id, { announce: true });
+  } finally {
+    setBusy(false);
+  }
+}
+
+async function handleWatchlistRefresh() {
+  if (!state.selectedWatchlistId) {
+    setMessage("Select a watchlist before running refresh.");
+    return;
+  }
+
+  try {
+    const response = await requestJson(
+      `/api/watchlists/${state.selectedWatchlistId}/refresh`,
+      { method: "POST" },
+    );
+    await loadWatchlists();
+    setMessage(
+      `Watchlist refresh complete: ${response.refreshed_companies} companies, ${response.refreshed_people} people, ${response.signals_upserted} signals.`,
+    );
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+async function handleResetFocus() {
+  state.focusLocationId = null;
+  state.selectedClusterId = null;
+  if (state.currentRun) {
+    setBusy(true);
+    try {
+      await loadRunSlices(state.currentRun.run_id);
+      setMessage("Map focus cleared.");
+    } finally {
+      setBusy(false);
+    }
+    return;
+  }
+  renderMap();
+}
+
+function handleActionClick(event) {
+  const target = event.target.closest("[data-action]");
+  if (!target) {
+    return;
+  }
+
+  const action = target.dataset.action;
+  if (action === "watchlist-add") {
+    addEntityToSelectedWatchlist(target.dataset.entityType, target.dataset.entityId);
+    return;
+  }
+  if (action === "select-watchlist") {
+    selectWatchlist(target.dataset.watchlistId);
+    return;
+  }
+  if (action === "remove-watchlist-item") {
+    removeWatchlistItem(target.dataset.watchlistId, target.dataset.itemId);
+  }
+}
+
+function handleMapClick(event) {
+  const target = event.target.closest("[data-cluster-id]");
+  if (!target) {
+    return;
+  }
+  const clusterId = target.dataset.clusterId;
+  const cluster = state.clusters?.clusters?.find((item) => item.cluster_id === clusterId);
+  if (!cluster) {
+    return;
+  }
+
+  state.selectedClusterId = clusterId;
+  const singleLocation = cluster.location_ids.length === 1 ? cluster.location_ids[0] : null;
+  if (singleLocation) {
+    state.focusLocationId = singleLocation;
+    if (state.currentRun) {
+      loadRunSlices(state.currentRun.run_id)
+        .then(() => {
+          setMessage(`Focused on ${cluster.labels[0] || "selected cluster"}.`);
+        })
+        .catch((error) => {
+          console.error(error);
+        });
+      return;
+    }
+  }
+
+  setMessage(`Selected cluster with ${cluster.entity_count} entities.`);
+  renderMap();
+}
+
+async function addEntityToSelectedWatchlist(entityType, entityId) {
+  if (!entityType || !entityId) {
+    return;
+  }
+  if (!state.selectedWatchlistId) {
+    setMessage("Create or select a watchlist before adding entities.");
+    return;
+  }
+
+  const body = { entity_type: entityType };
+  if (entityType === "company") {
+    body.company_id = entityId;
+  } else {
+    body.person_id = entityId;
+  }
+
+  try {
+    await requestJson(`/api/watchlists/${state.selectedWatchlistId}/items`, {
+      method: "POST",
+      body,
+    });
+    await loadWatchlists();
+    setMessage(`Tracked ${entityType} added to the selected watchlist.`);
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+async function removeWatchlistItem(watchlistId, itemId) {
+  if (!watchlistId || !itemId) {
+    return;
+  }
+
+  try {
+    await requestJson(`/api/watchlists/${watchlistId}/items/${itemId}`, {
+      method: "DELETE",
+    });
+    await loadWatchlists();
+    setMessage("Watchlist item removed.");
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+async function selectWatchlist(watchlistId) {
+  state.selectedWatchlistId = watchlistId;
+  if (watchlistId) {
+    window.localStorage.setItem(STORAGE_KEYS.watchlistId, watchlistId);
+    await loadWatchlistSignals(watchlistId);
+  } else {
+    window.localStorage.removeItem(STORAGE_KEYS.watchlistId);
+    state.watchlistSignals = [];
+  }
+  renderWatchlists();
+  renderSignals();
+}
+
+async function loadRun(runId, { announce = true } = {}) {
+  const run = await requestJson(`/api/runs/${runId}`);
+  state.currentRun = run;
+  window.localStorage.setItem(STORAGE_KEYS.runId, run.run_id);
+  updateRunUrl(run.run_id);
+
+  await Promise.all([
+    loadRunSlices(run.run_id),
+    loadLensSummary(run.run_id, run.lens),
+  ]);
+
+  if (announce) {
+    setMessage(
+      `${titleCase(run.lens)} run loaded with ${formatCount(totalPrimaryEntities(run.result_counts))} primary entities.`,
+    );
+  }
+  renderAll();
+}
+
+async function loadRunSlices(runId) {
+  const params = new URLSearchParams();
+  if (state.entityFilter !== "all") {
+    params.set("entity_type", state.entityFilter);
+  }
+
+  const entityParams = new URLSearchParams(params);
+  entityParams.set("limit", "24");
+  if (state.focusLocationId) {
+    entityParams.set("location_id", state.focusLocationId);
+  }
+
+  const clusterPath = `/api/runs/${runId}/clusters?${params.toString()}`;
+  const entityPath = `/api/runs/${runId}/entities?${entityParams.toString()}`;
+  const [clusters, entities] = await Promise.all([
+    requestJson(clusterPath),
+    requestJson(entityPath),
+  ]);
+  state.clusters = clusters;
+  state.entities = entities;
+  renderMap();
+  renderEntities();
+}
+
+async function loadLensSummary(runId, lens) {
+  const summaryPath = {
+    sales: `/api/runs/${runId}/sales-summary`,
+    recruiting: `/api/runs/${runId}/recruiting-summary`,
+    investor: `/api/runs/${runId}/investor-summary`,
+  }[lens];
+  state.summary = summaryPath ? await requestJson(summaryPath) : null;
+  renderSummary();
+}
+
+async function loadWatchlists({ quiet = false } = {}) {
+  try {
+    state.watchlists = await requestJson("/api/watchlists", { quiet });
+    const selectedExists = state.watchlists.some(
+      (watchlist) => watchlist.watchlist_id === state.selectedWatchlistId,
+    );
+    if (!selectedExists) {
+      state.selectedWatchlistId = state.watchlists[0]?.watchlist_id || null;
+    }
+    if (state.selectedWatchlistId) {
+      window.localStorage.setItem(STORAGE_KEYS.watchlistId, state.selectedWatchlistId);
+      await loadWatchlistSignals(state.selectedWatchlistId, { quiet: true });
+    } else {
+      window.localStorage.removeItem(STORAGE_KEYS.watchlistId);
+      state.watchlistSignals = [];
+    }
+    renderWatchlists();
+    renderSignals();
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+async function loadWatchlistSignals(watchlistId, { quiet = false } = {}) {
+  state.watchlistSignals = [];
+  if (!watchlistId) {
+    renderSignals();
+    return;
+  }
+  const response = await requestJson(`/api/watchlists/${watchlistId}/signals`, { quiet });
+  state.watchlistSignals = response.signals || [];
+  renderSignals();
+}
+
+async function loadAuthContext() {
+  try {
+    state.auth = await requestJson("/api/auth/me", { quiet: true });
+  } catch (error) {
+    console.error(error);
+  }
+  renderHeader();
+}
+
+async function loadServiceHealth() {
+  try {
+    const response = await requestJson("/health/live", { quiet: true });
+    state.liveStatus = response.status === "ok" ? "Live" : "Unavailable";
+  } catch (error) {
+    console.error(error);
+    state.liveStatus = "Offline";
+  }
+  renderHeader();
+}
+
+async function loadAdminMetrics() {
+  try {
+    state.adminMetrics = await requestJson("/api/admin/metrics", { quiet: true });
+  } catch (error) {
+    state.adminMetrics = null;
+  }
+  renderEvents();
+}
+
+function buildRunPayload() {
+  const form = refs.runForm.elements;
+  const common = {
+    lens: state.lens,
+    title: blankToNull(form.title.value),
+  };
+
+  const searchLimit = parseInteger(form.searchLimit.value, 25);
+  if (state.lens === "sales") {
+    return {
+      ...common,
+      input: {
+        search: {
+          fields: DEFAULT_FIELDS.sales,
+          limit: searchLimit,
+        },
+        preferred_industries: splitComma(form.salesPreferredIndustries.value),
+        top_company_limit: parseInteger(form.salesTopCompanyLimit.value, 5),
+        buyers_per_company: parseInteger(form.salesBuyersPerCompany.value, 3),
+        buyer_titles: splitComma(form.salesBuyerTitles.value),
+        buyer_seniorities: splitComma(form.salesBuyerSeniorities.value),
+      },
+    };
+  }
+
+  if (state.lens === "recruiting") {
+    const radiusLat = parseFloatOrNull(form.recruitingLat.value);
+    const radiusLng = parseFloatOrNull(form.recruitingLng.value);
+    const radiusKm = parseFloatOrNull(form.recruitingRadiusKm.value);
+    const radius =
+      radiusLat !== null && radiusLng !== null && radiusKm !== null
+        ? {
+            latitude: radiusLat,
+            longitude: radiusLng,
+            radius_km: radiusKm,
+          }
+        : null;
+    return {
+      ...common,
+      input: {
+        search: {
+          fields: DEFAULT_FIELDS.recruiting,
+          limit: searchLimit,
+        },
+        target_titles: splitComma(form.recruitingTitles.value),
+        target_seniorities: splitComma(form.recruitingSeniorities.value),
+        target_functions: splitComma(form.recruitingFunctions.value),
+        target_skills: splitComma(form.recruitingSkills.value),
+        top_candidate_limit: parseInteger(form.recruitingTopLimit.value, 12),
+        radius,
+      },
+    };
+  }
+
+  return {
+    ...common,
+    input: {
+      search: {
+        fields: DEFAULT_FIELDS.investor,
+        limit: searchLimit,
+      },
+      target_markets: splitComma(form.investorMarkets.value),
+      target_categories: splitComma(form.investorCategories.value),
+      target_industries: splitComma(form.investorIndustries.value),
+      min_headcount: parseIntegerOrNull(form.investorMinHeadcount.value),
+      max_headcount: parseIntegerOrNull(form.investorMaxHeadcount.value),
+      min_openings_growth_percent: parseFloatOrNull(form.investorMinOpeningsGrowth.value),
+      min_follower_growth_percent: parseFloatOrNull(form.investorMinFollowerGrowth.value),
+      top_company_limit: parseInteger(form.investorTopCompanyLimit.value, 5),
+      founders_per_company: parseInteger(form.investorFoundersPerCompany.value, 2),
+    },
+  };
+}
+
+function renderAll() {
+  renderHeader();
+  renderHero();
+  renderSummary();
+  renderEntities();
+  renderWatchlists();
+  renderSignals();
+  renderMap();
+}
+
+function renderHeader() {
+  refs.userBadge.textContent = state.auth
+    ? `${state.auth.user_id}${state.auth.is_admin ? " / admin" : ""}`
+    : "Unavailable";
+  refs.liveStatus.textContent = state.liveStatus;
+  refs.runBadge.textContent = state.currentRun ? titleCase(state.currentRun.lens) : "Idle";
+}
+
+function renderHero() {
+  if (!state.currentRun) {
+    refs.heroTitle.textContent = "No run selected";
+    refs.runMeta.textContent = "Waiting for input";
+    refs.statGrid.innerHTML = buildEmptyBlock(
+      "No run data yet. Launch one of the lenses to hydrate metrics, map clusters, and ranked cards.",
+    );
+    renderEvents();
+    return;
+  }
+
+  refs.heroTitle.textContent = state.currentRun.title || `${titleCase(state.currentRun.lens)} run`;
+  refs.runMeta.textContent = `${state.currentRun.status} / ${formatDateTime(state.currentRun.created_at)}`;
+
+  const statCards = summarizeRunStats();
+  refs.statGrid.innerHTML = statCards
+    .map(
+      (card) => `
+        <div class="stat-card">
+          <span class="status-inline">${escapeHtml(card.label)}</span>
+          <strong>${escapeHtml(card.value)}</strong>
+        </div>
+      `,
+    )
+    .join("");
+  renderEvents();
+}
+
+function renderEvents() {
+  const extras = state.adminMetrics
+    ? `
+      <div class="detail-grid">
+        <span class="pill soft">users ${formatCount(state.adminMetrics.users)}</span>
+        <span class="pill soft">runs ${formatCount(state.adminMetrics.search_runs)}</span>
+        <span class="pill soft">watchlists ${formatCount(state.adminMetrics.watchlists)}</span>
+      </div>
+    `
+    : "";
+  refs.eventStrip.innerHTML = `
+    <div class="event-message">${escapeHtml(state.message)}</div>
+    ${extras}
+  `;
+}
+
+function renderSummary() {
+  if (!state.summary || !state.currentRun) {
+    refs.summaryBody.innerHTML = buildEmptyBlock(
+      "Lens summaries show up here once a run finishes. Companies or people stay actionable from the ranked cards.",
+    );
+    return;
+  }
+
+  let content = "";
+  if (state.currentRun.lens === "sales") {
+    content = renderSalesSummary();
+  } else if (state.currentRun.lens === "recruiting") {
+    content = renderRecruitingSummary();
+  } else {
+    content = renderInvestorSummary();
+  }
+  refs.summaryBody.innerHTML = content || buildEmptyBlock("No ranked cards returned yet.");
+}
+
+function renderSalesSummary() {
+  const companies = state.summary.companies || [];
+  return companies
+    .map((company) => {
+      const buyers = (company.buyers || [])
+        .map(
+          (buyer) => `
+            <span class="pill soft">${escapeHtml(buyer.name)}${buyer.title ? ` / ${escapeHtml(buyer.title)}` : ""}</span>
+          `,
+        )
+        .join("");
+      return `
+        <article class="summary-card">
+          <div class="card-title-row">
+            <div class="card-title">
+              <h3>${escapeHtml(company.name)}</h3>
+              <p class="card-subtitle">${escapeHtml(joinParts([company.domain, company.industry]))}</p>
+            </div>
+            <span class="pill score">${formatScore(company.lens_score)}</span>
+          </div>
+          <div class="detail-grid">
+            <span class="pill warn">${formatCount(company.buyer_count)} buyers</span>
+            <span class="pill soft">${escapeHtml(company.funding_last_round_type || "No round")}</span>
+            <span class="pill soft">${escapeHtml(company.location.raw_label || "Location pending")}</span>
+          </div>
+          <div class="tone-bar"><div class="tone-fill" style="width: ${clampScore(company.lens_score)}%"></div></div>
+          <div class="card-meta">${buyers || '<span class="empty-state">No buyers attached for this company.</span>'}</div>
+          <div class="entity-actions">
+            <button
+              type="button"
+              class="secondary-button"
+              data-action="watchlist-add"
+              data-entity-type="company"
+              data-entity-id="${company.company_id}"
+            >Track company</button>
+          </div>
+        </article>
+      `;
+    })
+    .join("");
+}
+
+function renderRecruitingSummary() {
+  const candidates = state.summary.candidates || [];
+  return candidates
+    .map(
+      (candidate) => `
+        <article class="summary-card">
+          <div class="card-title-row">
+            <div class="card-title">
+              <h3>${escapeHtml(candidate.name)}</h3>
+              <p class="card-subtitle">${escapeHtml(joinParts([candidate.title, candidate.current_company_name]))}</p>
+            </div>
+            <span class="pill score">${formatScore(candidate.lens_score)}</span>
+          </div>
+          <div class="detail-grid">
+            <span class="pill warn">${escapeHtml(candidate.seniority || "Unknown seniority")}</span>
+            <span class="pill soft">${escapeHtml(candidate.function_category || "Function pending")}</span>
+            <span class="pill soft">${escapeHtml(candidate.location.raw_label || "Location pending")}</span>
+          </div>
+          <div class="tone-bar"><div class="tone-fill" style="width: ${clampScore(candidate.lens_score)}%"></div></div>
+          <p class="card-subtitle">${escapeHtml(candidate.headline || "No headline available.")}</p>
+          <div class="entity-actions">
+            <button
+              type="button"
+              class="secondary-button"
+              data-action="watchlist-add"
+              data-entity-type="person"
+              data-entity-id="${candidate.person_id}"
+            >Track candidate</button>
+          </div>
+        </article>
+      `,
+    )
+    .join("");
+}
+
+function renderInvestorSummary() {
+  const companies = state.summary.companies || [];
+  return companies
+    .map((company) => {
+      const founders = (company.founders || [])
+        .map(
+          (founder) => `
+            <span class="pill soft">${escapeHtml(founder.name)}${founder.title ? ` / ${escapeHtml(founder.title)}` : ""}</span>
+          `,
+        )
+        .join("");
+      const signals = (company.signals || [])
+        .map(
+          (signal) => `
+            <span class="pill signal">${escapeHtml(signal.signal_type)}</span>
+          `,
+        )
+        .join("");
+      return `
+        <article class="summary-card">
+          <div class="card-title-row">
+            <div class="card-title">
+              <h3>${escapeHtml(company.name)}</h3>
+              <p class="card-subtitle">${escapeHtml(joinParts([company.domain, company.industry]))}</p>
+            </div>
+            <span class="pill score">${formatScore(company.lens_score)}</span>
+          </div>
+          <div class="detail-grid">
+            <span class="pill warn">${formatCount(company.founder_count)} founders</span>
+            <span class="pill soft">${escapeHtml(company.location.raw_label || "Location pending")}</span>
+          </div>
+          <div class="tone-bar"><div class="tone-fill" style="width: ${clampScore(company.lens_score)}%"></div></div>
+          <div class="card-meta">${founders || '<span class="empty-state">No founders enriched.</span>'}</div>
+          <div class="card-meta">${signals || '<span class="empty-state">No investor signals recorded.</span>'}</div>
+          <div class="entity-actions">
+            <button
+              type="button"
+              class="secondary-button"
+              data-action="watchlist-add"
+              data-entity-type="company"
+              data-entity-id="${company.company_id}"
+            >Track company</button>
+          </div>
+        </article>
+      `;
+    })
+    .join("");
+}
+
+function renderEntities() {
+  const items = state.entities?.items || [];
+  refs.entityCountLabel.textContent = `${formatCount(items.length)} items`;
+  if (!items.length) {
+    refs.entityList.innerHTML = buildEmptyBlock(
+      state.currentRun
+        ? "No entities match the current filter or cluster focus."
+        : "Map entities land here after a run completes.",
+    );
+    return;
+  }
+
+  refs.entityList.innerHTML = items
+    .map(
+      (item) => `
+        <article class="entity-card">
+          <div class="card-title-row">
+            <div class="card-title">
+              <h3>${escapeHtml(item.name)}</h3>
+              <p class="card-subtitle">${escapeHtml(item.subtitle || item.entity_type)}</p>
+            </div>
+            <span class="pill score">${formatScore(item.lens_score)}</span>
+          </div>
+          <div class="detail-grid">
+            <span class="pill soft">${escapeHtml(item.location.raw_label || "Location pending")}</span>
+            <span class="pill soft">${escapeHtml(item.location.status || "missing")}</span>
+          </div>
+          <div class="entity-actions">
+            <button
+              type="button"
+              class="text-button"
+              data-action="watchlist-add"
+              data-entity-type="${item.entity_type}"
+              data-entity-id="${item.entity_id}"
+            >Add to watchlist</button>
+          </div>
+        </article>
+      `,
+    )
+    .join("");
+}
+
+function renderWatchlists() {
+  const watchlists = state.watchlists || [];
+  const selected = watchlists.find((item) => item.watchlist_id === state.selectedWatchlistId) || null;
+  refs.watchlistBadge.textContent = selected
+    ? `${selected.name} / ${formatCount(selected.item_count)} items`
+    : "No watchlist selected";
+
+  if (!watchlists.length) {
+    refs.watchlistList.innerHTML = buildEmptyBlock(
+      "Create a watchlist to track companies or people from the ranked cards.",
+    );
+    return;
+  }
+
+  refs.watchlistList.innerHTML = watchlists
+    .map((watchlist) => {
+      const isSelected = watchlist.watchlist_id === state.selectedWatchlistId;
+      const items = (watchlist.items || [])
+        .slice(0, 4)
+        .map(
+          (item) => `
+            <div class="watchlist-meta">
+              <span class="pill soft">${escapeHtml(item.entity.name)}</span>
+              <button
+                type="button"
+                class="text-button destructive"
+                data-action="remove-watchlist-item"
+                data-watchlist-id="${watchlist.watchlist_id}"
+                data-item-id="${item.item_id}"
+              >Remove</button>
+            </div>
+          `,
+        )
+        .join("");
+
+      return `
+        <article class="watchlist-card${isSelected ? " selected-card" : ""}">
+          <div class="card-title-row">
+            <div class="card-title">
+              <h3>${escapeHtml(watchlist.name)}</h3>
+              <p class="card-subtitle">${escapeHtml(watchlist.description || "No description")}</p>
+            </div>
+            <span class="pill warn">${formatCount(watchlist.item_count)} items</span>
+          </div>
+          <div class="watchlist-actions">
+            <button
+              type="button"
+              class="text-button"
+              data-action="select-watchlist"
+              data-watchlist-id="${watchlist.watchlist_id}"
+            >${isSelected ? "Selected" : "Open"}</button>
+            <span class="pill soft">${escapeHtml(watchlist.lens || "mixed")}</span>
+          </div>
+          ${items || '<div class="empty-state">No tracked entities yet.</div>'}
+        </article>
+      `;
+    })
+    .join("");
+}
+
+function renderSignals() {
+  if (!state.selectedWatchlistId) {
+    refs.signalTimeline.innerHTML = buildEmptyBlock(
+      "Select a watchlist to inspect the latest entity signals and refresh output.",
+    );
+    return;
+  }
+  if (!state.watchlistSignals.length) {
+    refs.signalTimeline.innerHTML = buildEmptyBlock(
+      "No signals recorded yet for this watchlist. Run refresh after enriching tracked entities.",
+    );
+    return;
+  }
+
+  refs.signalTimeline.innerHTML = state.watchlistSignals
+    .slice(0, 12)
+    .map(
+      (signal) => `
+        <article class="timeline-card">
+          <div class="card-title-row">
+            <div class="card-title">
+              <h3>${escapeHtml(signal.title || signal.signal_type)}</h3>
+              <p class="card-subtitle">${escapeHtml(joinParts([signal.entity_name, signal.entity_type]))}</p>
+            </div>
+            <span class="pill signal">${escapeHtml(signal.signal_type)}</span>
+          </div>
+          <p>${escapeHtml(signal.description || "No description provided.")}</p>
+          <div class="timeline-meta">
+            <span class="pill soft">${formatDateTime(signal.occurred_at || signal.created_at)}</span>
+            <span class="pill soft">confidence ${Math.round((signal.confidence || 0) * 100)}%</span>
+          </div>
+        </article>
+      `,
+    )
+    .join("");
+}
+
+function renderMap() {
+  const clusters = state.clusters?.clusters || [];
+  const summary = state.clusters?.summary;
+  refs.mapLegend.innerHTML = summary ? `
+      <div class="legend-row">
+        <span class="legend-chip"><span class="swatch" style="background:#ffb703"></span>Total ${formatCount(summary.total_entities)}</span>
+        <span class="legend-chip"><span class="swatch" style="background:#0f766e"></span>Mapped ${formatCount(summary.mapped_count)}</span>
+        <span class="legend-chip"><span class="swatch" style="background:#d95d39"></span>Unmapped ${formatCount(summary.unmapped_count)}</span>
+      </div>
+    ` : "";
+
+  if (!clusters.length) {
+    refs.mapSvg.innerHTML = buildMapSkeleton(
+      "<text x='490' y='270' class='map-empty'>No geo clusters available for the current selection.</text>",
+    );
+    refs.clusterDetail.innerHTML = "<p class='cluster-placeholder'>Select a run to render mapped clusters.</p>";
+    return;
+  }
+
+  const bounds = deriveBounds(clusters);
+  const nodes = clusters
+    .map((cluster) => renderClusterNode(cluster, bounds))
+    .join("");
+  refs.mapSvg.innerHTML = buildMapSkeleton(nodes);
+
+  const selected = clusters.find((cluster) => cluster.cluster_id === state.selectedClusterId);
+  refs.clusterDetail.innerHTML = selected
+    ? `
+        <div class="detail-grid">
+          <span class="pill soft">${formatCount(selected.entity_count)} entities</span>
+          <span class="pill soft">${formatCount(selected.location_count)} locations</span>
+        </div>
+        <p class="cluster-placeholder">${escapeHtml(selected.labels.join(" / ") || "Cluster focus")}</p>
+      `
+    : "<p class='cluster-placeholder'>Click a node to focus a location slice when a single location is present.</p>";
+}
+
+function renderClusterNode(cluster, bounds) {
+  const { x, y } = projectPoint(cluster.latitude, cluster.longitude, bounds);
+  const radius = cluster.is_cluster
+    ? Math.min(28, 10 + Math.log2(cluster.entity_count + 1) * 5)
+    : 9;
+  const fill = cluster.company_count && cluster.person_count
+    ? "#ffb703"
+    : cluster.company_count
+      ? "#0f766e"
+      : "#d95d39";
+  const opacity = cluster.cluster_id === state.selectedClusterId ? 1 : 0.88;
+  const label = cluster.is_cluster ? String(cluster.entity_count) : "";
+
+  return `
+    <g class="map-node" data-cluster-id="${cluster.cluster_id}" transform="translate(${x}, ${y})">
+      <circle class="map-node-glow" r="${radius + 8}" fill="${fill}" opacity="0.18"></circle>
+      <circle class="map-node-core" r="${radius}" fill="${fill}" opacity="${opacity}"></circle>
+      <circle class="map-node-ring" r="${radius + 2.5}" fill="none" stroke="rgba(255,248,237,0.75)" stroke-width="1.5"></circle>
+      ${label ? `<text class="map-node-text" text-anchor="middle" dy="5">${label}</text>` : ""}
+    </g>
+  `;
+}
+
+function buildMapSkeleton(nodes) {
+  const gridLines = [];
+  for (let x = 120; x <= 860; x += 148) {
+    gridLines.push(`<line class="map-grid-line" x1="${x}" y1="40" x2="${x}" y2="500"></line>`);
+  }
+  for (let y = 80; y <= 460; y += 76) {
+    gridLines.push(`<line class="map-grid-line" x1="40" y1="${y}" x2="940" y2="${y}"></line>`);
+  }
+  return `
+    <rect x="24" y="24" width="932" height="492" rx="28" class="map-surface"></rect>
+    <g class="map-grid">${gridLines.join("")}</g>
+    <path class="map-wave" d="M100 388C178 352 244 300 346 288C434 278 530 312 626 286C712 262 782 206 900 174"></path>
+    <path class="map-wave faint" d="M84 188C166 222 262 238 352 208C426 184 474 126 572 124C664 122 756 188 904 224"></path>
+    ${nodes}
+  `;
+}
+
+function deriveBounds(clusters) {
+  const lats = clusters.map((item) => item.latitude);
+  const lngs = clusters.map((item) => item.longitude);
+  const minLat = Math.min(...lats);
+  const maxLat = Math.max(...lats);
+  const minLng = Math.min(...lngs);
+  const maxLng = Math.max(...lngs);
+  const latPad = Math.max(4, (maxLat - minLat) * 0.18);
+  const lngPad = Math.max(6, (maxLng - minLng) * 0.18);
+  return {
+    minLat: clamp(minLat - latPad, -85, 85),
+    maxLat: clamp(maxLat + latPad, -85, 85),
+    minLng: clamp(minLng - lngPad, -180, 180),
+    maxLng: clamp(maxLng + lngPad, -180, 180),
+  };
+}
+
+function projectPoint(latitude, longitude, bounds) {
+  const width = 980;
+  const height = 540;
+  const padX = 56;
+  const padY = 48;
+  const usableWidth = width - padX * 2;
+  const usableHeight = height - padY * 2;
+  const x = padX + ((longitude - bounds.minLng) / (bounds.maxLng - bounds.minLng || 1)) * usableWidth;
+  const y = padY + (1 - (latitude - bounds.minLat) / (bounds.maxLat - bounds.minLat || 1)) * usableHeight;
+  return {
+    x: clamp(x, padX, width - padX),
+    y: clamp(y, padY, height - padY),
+  };
+}
+
+function summarizeRunStats() {
+  if (!state.currentRun) {
+    return [];
+  }
+  const counts = state.currentRun.result_counts || {};
+  const base = [
+    { label: "Status", value: titleCase(state.currentRun.status) },
+    {
+      label: "Primary entities",
+      value: formatCount(totalPrimaryEntities(counts)),
+    },
+    {
+      label: "Locations",
+      value: formatCount(counts.locations || state.clusters?.summary?.mapped_count || 0),
+    },
+  ];
+
+  if (state.currentRun.lens === "sales" && state.summary?.summary) {
+    return base.concat([
+      { label: "Buyers", value: formatCount(state.summary.summary.buyer_count) },
+      { label: "Average score", value: formatScore(state.summary.summary.average_company_score) },
+    ]);
+  }
+  if (state.currentRun.lens === "recruiting" && state.summary?.summary) {
+    return base.concat([
+      { label: "Employers", value: formatCount(state.summary.summary.employer_count) },
+      { label: "Average score", value: formatScore(state.summary.summary.average_candidate_score) },
+    ]);
+  }
+  if (state.currentRun.lens === "investor" && state.summary?.summary) {
+    return base.concat([
+      { label: "Founders", value: formatCount(state.summary.summary.founder_count) },
+      { label: "Signals", value: formatCount(state.summary.summary.signal_count) },
+    ]);
+  }
+  return base;
+}
+
+function totalPrimaryEntities(resultCounts) {
+  return resultCounts.companies || resultCounts.people || 0;
+}
+
+async function requestJson(path, { method = "GET", body, quiet = false } = {}) {
+  const options = {
+    method,
+    headers: {
+      Accept: "application/json",
+    },
+  };
+  if (body !== undefined) {
+    options.headers["Content-Type"] = "application/json";
+    options.body = JSON.stringify(body);
+  }
+
+  const response = await fetch(path, options);
+  const contentType = response.headers.get("content-type") || "";
+  const payload = contentType.includes("application/json")
+    ? await response.json()
+    : await response.text();
+
+  if (!response.ok) {
+    const message = payload?.error?.message || `Request failed with status ${response.status}.`;
+    if (!quiet) {
+      setMessage(message);
+    }
+    const error = new Error(message);
+    error.status = response.status;
+    error.payload = payload;
+    throw error;
+  }
+
+  return payload;
+}
+
+function setBusy(isBusy) {
+  state.isBusy = isBusy;
+  refs.runButton.disabled = isBusy;
+  refs.reloadRunButton.disabled = isBusy;
+  refs.refreshWatchlistButton.disabled = isBusy;
+}
+
+function setMessage(message) {
+  state.message = message;
+  renderEvents();
+}
+
+function updateRunUrl(runId) {
+  const url = new URL(window.location.href);
+  if (runId) {
+    url.searchParams.set("run", runId);
+  } else {
+    url.searchParams.delete("run");
+  }
+  window.history.replaceState({}, "", url);
+}
+
+function buildEmptyBlock(message) {
+  return `<div class="empty-state">${escapeHtml(message)}</div>`;
+}
+
+function splitComma(value) {
+  return value
+    .split(",")
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+function parseInteger(value, fallback) {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function parseIntegerOrNull(value) {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const parsed = Number.parseInt(trimmed, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseFloatOrNull(value) {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const parsed = Number.parseFloat(trimmed);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function blankToNull(value) {
+  const trimmed = value.trim();
+  return trimmed ? trimmed : null;
+}
+
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function formatCount(value) {
+  return new Intl.NumberFormat("en-US", { notation: "compact" }).format(Number(value || 0));
+}
+
+function formatScore(value) {
+  if (value === null || value === undefined) {
+    return "0";
+  }
+  return Number(value).toFixed(1);
+}
+
+function clampScore(value) {
+  return clamp(Number(value || 0), 0, 100);
+}
+
+function formatDateTime(value) {
+  if (!value) {
+    return "Pending";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return "Pending";
+  }
+  return new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  }).format(date);
+}
+
+function titleCase(value) {
+  return String(value || "")
+    .split("_")
+    .join(" ")
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function joinParts(parts) {
+  return parts.filter(Boolean).join(" / ");
+}
+
+function clamp(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}

--- a/app/ui/assets/favicon.svg
+++ b/app/ui/assets/favicon.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96 96" fill="none">
+  <rect width="96" height="96" rx="28" fill="#183C5B"/>
+  <path d="M18 62C28 40.5 41 29 57 26" stroke="#F6ECDD" stroke-width="6" stroke-linecap="round"/>
+  <path d="M30 72C47 51 62 45 78 43" stroke="#0F766E" stroke-width="8" stroke-linecap="round"/>
+  <circle cx="29" cy="68" r="8" fill="#FFB703"/>
+  <circle cx="59" cy="42" r="8" fill="#D95D39"/>
+  <circle cx="75" cy="44" r="7" fill="#F6ECDD"/>
+</svg>

--- a/app/ui/assets/index.html
+++ b/app/ui/assets/index.html
@@ -1,0 +1,374 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Locus Workbench</title>
+    <meta
+      name="description"
+      content="Operator shell for Locus: launch sales, recruiting, and investor runs against the Python backend."
+    />
+    <link rel="icon" type="image/svg+xml" href="/ui/favicon.svg" />
+    <link rel="stylesheet" href="/ui/styles.css" />
+  </head>
+  <body>
+    <div class="ambient ambient-one"></div>
+    <div class="ambient ambient-two"></div>
+    <div class="noise"></div>
+
+    <header class="masthead">
+      <div>
+        <p class="eyebrow">Map Workbench</p>
+        <h1>Locus</h1>
+        <p class="tagline">
+          Build the engine first. Scan clusters, inspect entities, and push watchlists from a single operator surface.
+        </p>
+      </div>
+      <div class="masthead-status">
+        <div class="status-chip">
+          <span class="status-label">API</span>
+          <strong id="liveStatus">Checking</strong>
+        </div>
+        <div class="status-chip">
+          <span class="status-label">User</span>
+          <strong id="userBadge">Loading</strong>
+        </div>
+        <div class="status-chip accent">
+          <span class="status-label">Run</span>
+          <strong id="runBadge">Idle</strong>
+        </div>
+      </div>
+    </header>
+
+    <main class="workspace">
+      <section class="panel control-panel">
+        <div class="panel-head">
+          <div>
+            <p class="eyebrow">Mission Control</p>
+            <h2>Lens Builder</h2>
+          </div>
+          <button type="button" class="ghost-button" id="resetFocusButton">Reset focus</button>
+        </div>
+
+        <div class="lens-switch" role="tablist" aria-label="Lens selector">
+          <button type="button" class="lens-pill active" data-lens="sales">Sales</button>
+          <button type="button" class="lens-pill" data-lens="recruiting">Recruiting</button>
+          <button type="button" class="lens-pill" data-lens="investor">Investor</button>
+        </div>
+
+        <form id="runForm" class="stack">
+          <label class="field">
+            <span>Run title</span>
+            <input
+              type="text"
+              name="title"
+              placeholder="West Coast devtools targets"
+              value="Priority motion"
+            />
+          </label>
+
+          <div class="field-grid two">
+            <label class="field">
+              <span>Search limit</span>
+              <input type="number" name="searchLimit" min="1" max="100" value="25" />
+            </label>
+            <label class="field">
+              <span>Entity filter</span>
+              <select id="entityFilter">
+                <option value="all">All entities</option>
+                <option value="company">Companies only</option>
+                <option value="person">People only</option>
+              </select>
+            </label>
+          </div>
+
+          <section class="lens-fields active" data-lens-panel="sales">
+            <div class="field-grid two">
+              <label class="field">
+                <span>Preferred industries</span>
+                <input
+                  type="text"
+                  name="salesPreferredIndustries"
+                  placeholder="Software, AI, Fintech"
+                  value="Software, AI"
+                />
+              </label>
+              <label class="field">
+                <span>Top companies</span>
+                <input type="number" name="salesTopCompanyLimit" min="1" max="25" value="5" />
+              </label>
+            </div>
+
+            <div class="field-grid two">
+              <label class="field">
+                <span>Buyers per company</span>
+                <input type="number" name="salesBuyersPerCompany" min="0" max="25" value="3" />
+              </label>
+              <label class="field">
+                <span>Buyer seniorities</span>
+                <input
+                  type="text"
+                  name="salesBuyerSeniorities"
+                  placeholder="cxo, vp, director"
+                  value="cxo, vp, director"
+                />
+              </label>
+            </div>
+
+            <label class="field">
+              <span>Buyer titles</span>
+              <input
+                type="text"
+                name="salesBuyerTitles"
+                placeholder="VP Sales, Head of Sales, Founder"
+                value="VP Sales, Head of Sales, Founder"
+              />
+            </label>
+          </section>
+
+          <section class="lens-fields" data-lens-panel="recruiting" hidden>
+            <div class="field-grid two">
+              <label class="field">
+                <span>Target titles</span>
+                <input
+                  type="text"
+                  name="recruitingTitles"
+                  placeholder="VP Engineering, Staff Engineer"
+                  value="VP Engineering, Staff Engineer"
+                />
+              </label>
+              <label class="field">
+                <span>Top candidates</span>
+                <input type="number" name="recruitingTopLimit" min="1" max="100" value="12" />
+              </label>
+            </div>
+
+            <div class="field-grid two">
+              <label class="field">
+                <span>Target seniorities</span>
+                <input
+                  type="text"
+                  name="recruitingSeniorities"
+                  placeholder="vp, director"
+                  value="vp, director"
+                />
+              </label>
+              <label class="field">
+                <span>Target functions</span>
+                <input
+                  type="text"
+                  name="recruitingFunctions"
+                  placeholder="engineering, product"
+                  value="engineering"
+                />
+              </label>
+            </div>
+
+            <label class="field">
+              <span>Target skills</span>
+              <input
+                type="text"
+                name="recruitingSkills"
+                placeholder="Python, distributed systems"
+                value="Python, distributed systems"
+              />
+            </label>
+
+            <div class="field-grid three">
+              <label class="field">
+                <span>Radius latitude</span>
+                <input type="number" step="0.0001" name="recruitingLat" placeholder="12.9716" />
+              </label>
+              <label class="field">
+                <span>Radius longitude</span>
+                <input type="number" step="0.0001" name="recruitingLng" placeholder="77.5946" />
+              </label>
+              <label class="field">
+                <span>Radius km</span>
+                <input type="number" step="1" min="1" max="1000" name="recruitingRadiusKm" placeholder="50" />
+              </label>
+            </div>
+          </section>
+
+          <section class="lens-fields" data-lens-panel="investor" hidden>
+            <div class="field-grid two">
+              <label class="field">
+                <span>Target markets</span>
+                <input
+                  type="text"
+                  name="investorMarkets"
+                  placeholder="AI Infrastructure, Devtools"
+                  value="AI Infrastructure, Developer Tools"
+                />
+              </label>
+              <label class="field">
+                <span>Target categories</span>
+                <input
+                  type="text"
+                  name="investorCategories"
+                  placeholder="Developer Tools"
+                  value="Developer Tools"
+                />
+              </label>
+            </div>
+
+            <div class="field-grid two">
+              <label class="field">
+                <span>Target industries</span>
+                <input
+                  type="text"
+                  name="investorIndustries"
+                  placeholder="Software, Manufacturing"
+                  value="Software"
+                />
+              </label>
+              <label class="field">
+                <span>Top companies</span>
+                <input type="number" name="investorTopCompanyLimit" min="1" max="25" value="5" />
+              </label>
+            </div>
+
+            <div class="field-grid three">
+              <label class="field">
+                <span>Min headcount</span>
+                <input type="number" name="investorMinHeadcount" min="1" placeholder="25" />
+              </label>
+              <label class="field">
+                <span>Max headcount</span>
+                <input type="number" name="investorMaxHeadcount" min="1" placeholder="500" />
+              </label>
+              <label class="field">
+                <span>Founders per company</span>
+                <input type="number" name="investorFoundersPerCompany" min="0" max="25" value="2" />
+              </label>
+            </div>
+
+            <div class="field-grid two">
+              <label class="field">
+                <span>Min hiring growth %</span>
+                <input type="number" step="1" name="investorMinOpeningsGrowth" placeholder="20" />
+              </label>
+              <label class="field">
+                <span>Min follower growth %</span>
+                <input type="number" step="1" name="investorMinFollowerGrowth" placeholder="15" />
+              </label>
+            </div>
+          </section>
+
+          <div class="action-row">
+            <button type="submit" class="primary-button" id="runButton">Launch run</button>
+            <p class="microcopy" id="formHint">
+              Runs execute directly against the live Python APIs. Lens summaries and watchlists hydrate from persisted backend state.
+            </p>
+          </div>
+        </form>
+      </section>
+
+      <section class="stage-column">
+        <section class="panel hero-panel">
+          <div class="panel-head">
+            <div>
+              <p class="eyebrow">Current Run</p>
+              <h2 id="heroTitle">No run selected</h2>
+            </div>
+            <div class="panel-actions">
+              <span class="status-inline" id="runMeta">Waiting for input</span>
+            </div>
+          </div>
+          <div class="stat-grid" id="statGrid"></div>
+          <div class="event-strip" id="eventStrip">
+            <div class="event-message">Launch a lens run to populate the map, summary cards, and watchlists.</div>
+          </div>
+        </section>
+
+        <section class="panel map-panel">
+          <div class="panel-head">
+            <div>
+              <p class="eyebrow">Signal Map</p>
+              <h2>Geo clusters</h2>
+            </div>
+            <div class="panel-actions">
+              <button type="button" class="ghost-button" id="reloadRunButton">Reload run</button>
+            </div>
+          </div>
+          <div class="map-frame">
+            <svg id="mapSvg" viewBox="0 0 980 540" role="img" aria-label="Cluster map"></svg>
+            <div class="map-overlay">
+              <div class="map-legend" id="mapLegend"></div>
+              <div class="cluster-detail" id="clusterDetail">
+                <p class="cluster-placeholder">Map focus appears here when you select a cluster.</p>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section class="panel entities-panel">
+          <div class="panel-head">
+            <div>
+              <p class="eyebrow">Run Entities</p>
+              <h2>Map slice</h2>
+            </div>
+            <span class="status-inline" id="entityCountLabel">0 items</span>
+          </div>
+          <div class="entity-list" id="entityList"></div>
+        </section>
+      </section>
+
+      <aside class="intel-column">
+        <section class="panel summary-panel">
+          <div class="panel-head">
+            <div>
+              <p class="eyebrow">Lens Output</p>
+              <h2>Ranked cards</h2>
+            </div>
+          </div>
+          <div class="summary-body" id="summaryBody"></div>
+        </section>
+
+        <section class="panel watchlist-panel">
+          <div class="panel-head">
+            <div>
+              <p class="eyebrow">Watchlists</p>
+              <h2>Tracked entities</h2>
+            </div>
+          </div>
+
+          <form id="watchlistForm" class="stack compact">
+            <label class="field">
+              <span>Name</span>
+              <input type="text" name="watchlistName" placeholder="Priority board" required />
+            </label>
+            <label class="field">
+              <span>Description</span>
+              <input
+                type="text"
+                name="watchlistDescription"
+                placeholder="Targets to refresh after every run"
+              />
+            </label>
+            <button type="submit" class="secondary-button">Create watchlist</button>
+          </form>
+
+          <div class="watchlist-toolbar">
+            <span class="status-inline" id="watchlistBadge">No watchlist selected</span>
+            <button type="button" class="ghost-button" id="refreshWatchlistButton">Refresh selected</button>
+          </div>
+
+          <div class="watchlist-list" id="watchlistList"></div>
+        </section>
+
+        <section class="panel signals-panel">
+          <div class="panel-head">
+            <div>
+              <p class="eyebrow">Signal Timeline</p>
+              <h2>Refresh output</h2>
+            </div>
+          </div>
+          <div class="timeline" id="signalTimeline"></div>
+        </section>
+      </aside>
+    </main>
+
+    <script type="module" src="/ui/app.js"></script>
+  </body>
+</html>

--- a/app/ui/assets/styles.css
+++ b/app/ui/assets/styles.css
@@ -1,0 +1,738 @@
+:root {
+  --bg: #f5ecdd;
+  --bg-strong: #f1e4cf;
+  --panel: rgba(255, 250, 239, 0.84);
+  --panel-strong: rgba(255, 247, 233, 0.96);
+  --ink: #13243b;
+  --muted: #5a6677;
+  --line: rgba(19, 36, 59, 0.12);
+  --line-strong: rgba(19, 36, 59, 0.22);
+  --teal: #0f766e;
+  --teal-soft: rgba(15, 118, 110, 0.16);
+  --amber: #d97706;
+  --amber-soft: rgba(217, 119, 6, 0.16);
+  --coral: #d95d39;
+  --coral-soft: rgba(217, 93, 57, 0.16);
+  --slate: #17324f;
+  --slate-soft: rgba(23, 50, 79, 0.06);
+  --map-surface: #183c5b;
+  --map-line: rgba(247, 237, 220, 0.18);
+  --shadow: 0 24px 90px rgba(26, 39, 56, 0.12);
+  --radius-lg: 28px;
+  --radius-md: 18px;
+  --radius-sm: 12px;
+  --display-font: "Avenir Next", "Trebuchet MS", "Segoe UI", sans-serif;
+  --body-font: "Avenir Next", "Segoe UI", sans-serif;
+  --mono-font: "IBM Plex Mono", "SFMono-Regular", "Menlo", monospace;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+}
+
+body {
+  background:
+    radial-gradient(circle at top left, rgba(15, 118, 110, 0.18), transparent 28%),
+    radial-gradient(circle at bottom right, rgba(217, 119, 6, 0.12), transparent 30%),
+    linear-gradient(180deg, #faf3e8 0%, var(--bg) 52%, #ede0ca 100%);
+  color: var(--ink);
+  font-family: var(--body-font);
+  position: relative;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background:
+    linear-gradient(90deg, rgba(19, 36, 59, 0.035) 1px, transparent 1px),
+    linear-gradient(rgba(19, 36, 59, 0.035) 1px, transparent 1px);
+  background-size: 46px 46px;
+  pointer-events: none;
+  opacity: 0.35;
+}
+
+.ambient,
+.noise {
+  pointer-events: none;
+  position: fixed;
+  inset: 0;
+}
+
+.ambient-one {
+  background: radial-gradient(circle at 18% 18%, rgba(255, 183, 3, 0.16), transparent 22%);
+}
+
+.ambient-two {
+  background: radial-gradient(circle at 82% 72%, rgba(15, 118, 110, 0.14), transparent 26%);
+}
+
+.noise {
+  background-image:
+    radial-gradient(rgba(19, 36, 59, 0.035) 0.8px, transparent 0.8px),
+    radial-gradient(rgba(255, 255, 255, 0.2) 0.8px, transparent 0.8px);
+  background-position: 0 0, 16px 16px;
+  background-size: 32px 32px;
+  mix-blend-mode: multiply;
+  opacity: 0.4;
+}
+
+.masthead,
+.workspace {
+  position: relative;
+  z-index: 1;
+}
+
+.masthead {
+  align-items: end;
+  display: flex;
+  gap: 24px;
+  justify-content: space-between;
+  padding: 28px 28px 18px;
+}
+
+.eyebrow {
+  color: var(--teal);
+  font-family: var(--mono-font);
+  font-size: 0.76rem;
+  letter-spacing: 0.18em;
+  margin: 0 0 10px;
+  text-transform: uppercase;
+}
+
+.masthead h1,
+.panel-head h2,
+.hero-panel h2 {
+  font-family: var(--display-font);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  margin: 0;
+}
+
+.masthead h1 {
+  font-size: clamp(2.7rem, 6vw, 4.6rem);
+  line-height: 0.95;
+}
+
+.tagline {
+  color: var(--muted);
+  font-size: 1rem;
+  line-height: 1.55;
+  margin: 12px 0 0;
+  max-width: 720px;
+}
+
+.masthead-status {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: end;
+}
+
+.status-chip {
+  backdrop-filter: blur(12px);
+  background: rgba(255, 250, 239, 0.74);
+  border: 1px solid rgba(19, 36, 59, 0.08);
+  border-radius: 999px;
+  box-shadow: 0 10px 30px rgba(19, 36, 59, 0.08);
+  min-width: 122px;
+  padding: 10px 16px;
+}
+
+.status-chip.accent {
+  background: rgba(15, 118, 110, 0.12);
+}
+
+.status-label,
+.status-inline {
+  color: var(--muted);
+  display: block;
+  font-family: var(--mono-font);
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.status-chip strong {
+  display: block;
+  margin-top: 4px;
+}
+
+.workspace {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: minmax(310px, 360px) minmax(0, 1fr) minmax(300px, 360px);
+  padding: 0 28px 28px;
+}
+
+.stage-column,
+.intel-column {
+  display: grid;
+  gap: 20px;
+}
+
+.panel {
+  backdrop-filter: blur(18px);
+  background: var(--panel);
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow);
+  overflow: hidden;
+  position: relative;
+}
+
+.panel::after {
+  border: 1px solid rgba(255, 255, 255, 0.65);
+  border-radius: calc(var(--radius-lg) - 4px);
+  content: "";
+  inset: 10px;
+  pointer-events: none;
+  position: absolute;
+}
+
+.panel-head {
+  align-items: start;
+  display: flex;
+  gap: 16px;
+  justify-content: space-between;
+  padding: 22px 22px 0;
+}
+
+.panel-head h2 {
+  font-size: 1.38rem;
+}
+
+.panel-actions,
+.watchlist-toolbar {
+  align-items: center;
+  display: flex;
+  gap: 10px;
+}
+
+.stack {
+  display: grid;
+  gap: 14px;
+  padding: 22px;
+}
+
+.stack.compact {
+  padding-bottom: 12px;
+}
+
+.field-grid {
+  display: grid;
+  gap: 12px;
+}
+
+.field-grid.two {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.field-grid.three {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.field {
+  display: grid;
+  gap: 8px;
+}
+
+.field span {
+  color: var(--muted);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+input,
+select,
+button,
+textarea {
+  font: inherit;
+}
+
+input,
+select {
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(19, 36, 59, 0.09);
+  border-radius: var(--radius-sm);
+  color: var(--ink);
+  min-height: 48px;
+  padding: 12px 14px;
+}
+
+input::placeholder {
+  color: #8692a4;
+}
+
+input:focus,
+select:focus,
+button:focus {
+  outline: 2px solid rgba(15, 118, 110, 0.22);
+  outline-offset: 2px;
+}
+
+.lens-switch {
+  display: grid;
+  gap: 10px;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  padding: 0 22px;
+}
+
+.lens-pill,
+.ghost-button,
+.secondary-button,
+.primary-button {
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+  min-height: 46px;
+  transition:
+    transform 160ms ease,
+    box-shadow 160ms ease,
+    background-color 160ms ease;
+}
+
+.lens-pill {
+  background: rgba(19, 36, 59, 0.06);
+  color: var(--ink);
+  font-weight: 700;
+}
+
+.lens-pill.active {
+  background: linear-gradient(135deg, var(--teal), #12897f);
+  box-shadow: 0 12px 28px rgba(15, 118, 110, 0.24);
+  color: white;
+  transform: translateY(-1px);
+}
+
+.ghost-button {
+  background: rgba(19, 36, 59, 0.06);
+  color: var(--ink);
+  padding: 0 16px;
+}
+
+.secondary-button {
+  background: linear-gradient(135deg, rgba(23, 50, 79, 0.95), rgba(19, 36, 59, 0.9));
+  color: white;
+  padding: 0 18px;
+}
+
+.primary-button {
+  background: linear-gradient(135deg, var(--coral), #f18f01);
+  box-shadow: 0 16px 32px rgba(217, 93, 57, 0.24);
+  color: white;
+  padding: 0 22px;
+}
+
+.primary-button:hover,
+.secondary-button:hover,
+.ghost-button:hover,
+.lens-pill:hover {
+  transform: translateY(-1px);
+}
+
+button:disabled {
+  cursor: wait;
+  opacity: 0.72;
+  transform: none;
+}
+
+.action-row {
+  align-items: center;
+  display: grid;
+  gap: 14px;
+}
+
+.microcopy {
+  color: var(--muted);
+  font-size: 0.88rem;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.lens-fields {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.38), rgba(255, 255, 255, 0.2));
+  border: 1px solid rgba(19, 36, 59, 0.08);
+  border-radius: 20px;
+  display: grid;
+  gap: 12px;
+  padding: 16px;
+}
+
+.hero-panel {
+  background:
+    linear-gradient(120deg, rgba(15, 118, 110, 0.1), transparent 36%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.35), rgba(255, 255, 255, 0.12));
+}
+
+.stat-grid {
+  display: grid;
+  gap: 12px;
+  grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+  padding: 22px;
+}
+
+.stat-card {
+  background: rgba(255, 255, 255, 0.66);
+  border: 1px solid rgba(19, 36, 59, 0.08);
+  border-radius: 18px;
+  padding: 14px 16px;
+}
+
+.stat-card strong {
+  display: block;
+  font-family: var(--display-font);
+  font-size: 1.3rem;
+  margin-top: 4px;
+}
+
+.event-strip {
+  background: rgba(19, 36, 59, 0.04);
+  border-top: 1px solid rgba(19, 36, 59, 0.08);
+  min-height: 58px;
+  padding: 14px 22px 20px;
+}
+
+.event-message {
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.map-panel {
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.28), rgba(255, 255, 255, 0.08)),
+    rgba(255, 255, 255, 0.78);
+}
+
+.map-frame {
+  margin: 18px 22px 22px;
+  min-height: 540px;
+  position: relative;
+}
+
+.map-frame::before {
+  background:
+    linear-gradient(180deg, rgba(247, 237, 220, 0.12), rgba(247, 237, 220, 0.02)),
+    radial-gradient(circle at 18% 18%, rgba(255, 183, 3, 0.16), transparent 28%),
+    radial-gradient(circle at 82% 75%, rgba(15, 118, 110, 0.18), transparent 30%),
+    var(--map-surface);
+  border-radius: 26px;
+  content: "";
+  inset: 0;
+  position: absolute;
+}
+
+#mapSvg {
+  border-radius: 26px;
+  display: block;
+  height: 540px;
+  overflow: hidden;
+  position: relative;
+  width: 100%;
+  z-index: 1;
+}
+
+.map-overlay {
+  display: grid;
+  gap: 14px;
+  grid-template-columns: minmax(0, 1fr);
+  inset: 16px;
+  pointer-events: none;
+  position: absolute;
+  z-index: 2;
+}
+
+.map-legend,
+.cluster-detail {
+  backdrop-filter: blur(12px);
+  background: rgba(8, 25, 41, 0.48);
+  border: 1px solid rgba(247, 237, 220, 0.15);
+  border-radius: 20px;
+  color: rgba(255, 248, 237, 0.94);
+  max-width: 420px;
+  padding: 12px 14px;
+}
+
+.cluster-detail {
+  align-self: end;
+}
+
+.cluster-placeholder {
+  color: rgba(255, 248, 237, 0.72);
+  margin: 0;
+}
+
+.legend-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.legend-chip {
+  align-items: center;
+  background: rgba(247, 237, 220, 0.08);
+  border-radius: 999px;
+  display: inline-flex;
+  gap: 8px;
+  padding: 8px 10px;
+}
+
+.swatch {
+  border-radius: 999px;
+  display: inline-block;
+  height: 10px;
+  width: 10px;
+}
+
+.entities-panel,
+.summary-panel,
+.watchlist-panel,
+.signals-panel {
+  min-height: 220px;
+}
+
+.entity-list,
+.summary-body,
+.watchlist-list,
+.timeline {
+  display: grid;
+  gap: 12px;
+  padding: 18px 22px 22px;
+}
+
+.entity-card,
+.summary-card,
+.watchlist-card,
+.timeline-card {
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid rgba(19, 36, 59, 0.08);
+  border-radius: 20px;
+  display: grid;
+  gap: 10px;
+  padding: 16px;
+}
+
+.selected-card {
+  border-color: rgba(15, 118, 110, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(15, 118, 110, 0.14);
+}
+
+.summary-card {
+  gap: 12px;
+}
+
+.card-topline,
+.card-meta,
+.watchlist-meta,
+.timeline-meta,
+.detail-grid {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.card-title-row {
+  align-items: start;
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+}
+
+.card-title h3,
+.watchlist-card h3,
+.timeline-card h3 {
+  font-family: var(--display-font);
+  font-size: 1.06rem;
+  margin: 0;
+}
+
+.card-subtitle,
+.timeline-card p,
+.watchlist-card p {
+  color: var(--muted);
+  margin: 0;
+}
+
+.pill {
+  border-radius: 999px;
+  display: inline-flex;
+  font-family: var(--mono-font);
+  font-size: 0.72rem;
+  letter-spacing: 0.02em;
+  padding: 6px 9px;
+  text-transform: uppercase;
+}
+
+.pill.score {
+  background: var(--teal-soft);
+  color: var(--teal);
+}
+
+.pill.warn {
+  background: var(--amber-soft);
+  color: var(--amber);
+}
+
+.pill.signal {
+  background: var(--coral-soft);
+  color: var(--coral);
+}
+
+.pill.soft {
+  background: rgba(19, 36, 59, 0.06);
+  color: var(--muted);
+}
+
+.entity-actions,
+.watchlist-actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.text-button {
+  background: none;
+  border: none;
+  color: var(--teal);
+  cursor: pointer;
+  font-weight: 700;
+  padding: 0;
+}
+
+.text-button.destructive {
+  color: var(--coral);
+}
+
+.empty-state {
+  color: var(--muted);
+  line-height: 1.6;
+  padding: 8px 0;
+}
+
+.detail-grid {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.tone-bar {
+  border-radius: 999px;
+  height: 9px;
+  overflow: hidden;
+  width: 100%;
+}
+
+.tone-fill {
+  background: linear-gradient(90deg, var(--coral), #ffb703, var(--teal));
+  border-radius: inherit;
+  height: 100%;
+}
+
+.mono {
+  font-family: var(--mono-font);
+}
+
+.map-surface {
+  fill: rgba(10, 26, 43, 0.16);
+  stroke: rgba(247, 237, 220, 0.12);
+  stroke-width: 1.5;
+}
+
+.map-grid-line {
+  stroke: var(--map-line);
+  stroke-width: 1;
+}
+
+.map-wave {
+  fill: none;
+  stroke: rgba(247, 237, 220, 0.28);
+  stroke-linecap: round;
+  stroke-width: 2.5;
+}
+
+.map-wave.faint {
+  opacity: 0.38;
+}
+
+.map-node {
+  cursor: pointer;
+  transition: transform 160ms ease;
+}
+
+.map-node:hover {
+  transform: scale(1.04);
+}
+
+.map-node-text {
+  fill: rgba(255, 248, 237, 0.96);
+  font-family: var(--mono-font);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.map-empty {
+  fill: rgba(255, 248, 237, 0.7);
+  font-family: var(--display-font);
+  font-size: 20px;
+  letter-spacing: 0.01em;
+}
+
+@media (max-width: 1280px) {
+  .workspace {
+    grid-template-columns: minmax(280px, 340px) minmax(0, 1fr);
+  }
+
+  .intel-column {
+    grid-column: 1 / -1;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 980px) {
+  .masthead {
+    align-items: start;
+    flex-direction: column;
+  }
+
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .intel-column {
+    grid-template-columns: 1fr;
+  }
+
+  .field-grid.two,
+  .field-grid.three {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .masthead,
+  .workspace {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+
+  .lens-switch {
+    grid-template-columns: 1fr;
+  }
+
+  .map-frame {
+    min-height: 420px;
+  }
+
+  #mapSvg {
+    height: 420px;
+  }
+}

--- a/app/ui/routes.py
+++ b/app/ui/routes.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import APIRouter
+from fastapi.responses import FileResponse
+
+ASSETS_DIR = Path(__file__).resolve().parent / "assets"
+
+router = APIRouter(include_in_schema=False)
+
+
+def get_ui_assets_dir() -> Path:
+    return ASSETS_DIR
+
+
+def _index_file() -> Path:
+    return ASSETS_DIR / "index.html"
+
+
+@router.get("/")
+def get_workbench() -> FileResponse:
+    return FileResponse(_index_file())
+
+
+@router.get("/workbench")
+def get_workbench_alias() -> FileResponse:
+    return FileResponse(_index_file())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dev = [
 
 [tool.hatch.build.targets.wheel]
 packages = ["app"]
+include = ["app/ui/assets/*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,25 @@
+def test_root_serves_workbench_shell(client):
+    response = client.get("/")
+
+    assert response.status_code == 200
+    assert "text/html" in response.headers["content-type"]
+    assert "Locus Workbench" in response.text
+    assert "/ui/app.js" in response.text
+
+
+def test_ui_assets_are_served(client):
+    stylesheet = client.get("/ui/styles.css")
+    script = client.get("/ui/app.js")
+    favicon = client.get("/ui/favicon.svg")
+
+    assert stylesheet.status_code == 200
+    assert "text/css" in stylesheet.headers["content-type"]
+    assert "workspace" in stylesheet.text
+
+    assert script.status_code == 200
+    assert "javascript" in script.headers["content-type"]
+    assert "const state" in script.text
+    assert "requestJson" in script.text
+
+    assert favicon.status_code == 200
+    assert "image/svg+xml" in favicon.headers["content-type"]


### PR DESCRIPTION
## What changed
- added a FastAPI-served frontend shell at `/` and `/workbench`
- added custom HTML, CSS, and JavaScript assets for the map workbench
- wired the shell to existing run, summary, cluster, entity, watchlist, and signal APIs
- added route coverage for the UI shell and static assets

## Why this changed
The backend engine is already on `main`, so this reopens the frontend work as a clean PR directly against `main`.

## Impact
- users can launch sales, recruiting, and investor runs from one UI
- map clusters, ranked summaries, entities, watchlists, and signals are visible in a single screen
- the app can be served directly from the Python backend

## Validation
- uv run --with ruff ruff check .
- uv run pytest
- node --check app/ui/assets/app.js
